### PR TITLE
Split out URL from the deploy script

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,11 +26,9 @@ jobs:
         unzip Linux.zip -d API/
     - name: Build docs
       run: |
-        url="https://rascalsoftware.github.io/RAT-Docs/"
-        echo -n ${url} > source/url.txt
+        export RAT_URL="https://rascalsoftware.github.io/RAT-Docs/"
+        export RAT_VERSION="dev"
         python build_docs.py
-      env:
-        GH_TOKEN: ${{ github.token }}
     - name: Checkout gh-pages
       if: github.ref == 'refs/heads/main'
       uses: actions/checkout@v4
@@ -40,7 +38,7 @@ jobs:
     - name: Deploy Docs
       if: github.ref == 'refs/heads/main'
       run: |
-        python deploy.py ${{github.ref}}
+        python deploy.py
         cd _web
         git config user.name github-actions
         git config user.email github-actions@github.com

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,6 +41,9 @@ jobs:
         path: _web
     - name: Build and Deploy Docs
       run: |
+        url=$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')
+        echo $url
+        echo $url > source/url.txt
         make html
         python deploy.py ${{github.ref}}
         cd _web
@@ -49,3 +52,5 @@ jobs:
         git add -A
         git commit -m "Publish Documentation" || true
         git push
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,12 +22,17 @@ jobs:
     - name: Set up MATLAB
       uses: matlab-actions/setup-matlab@v2
       with:
-        release: R2024a
+        release: R2023b
+        cache: true
+    - name: Run script
+      uses: matlab-actions/run-command@v2
+      with:
+        command: disp("Hello World")
     - name: Set up Python 
       uses: actions/setup-python@v4
     - name: Install dependencies
       run: |
-        export LD_LIBRARY_PATH=/opt/hostedtoolcache/MATLAB/2024.1.999/x64/bin/glnxa64/:$LD_LIBARY_PATH
+        export LD_LIBRARY_PATH=/opt/hostedtoolcache/MATLAB/2023.2.999/x64/bin/glnxa64/:$LD_LIBARY_PATH
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Download MATLAB RAT

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -8,31 +8,16 @@ on:
 
 jobs: 
   build:
-    runs-on: ubuntu-latest
+    runs-on: Linux
 
     steps:
     - uses: actions/checkout@v4      
-      with:
-        submodules: true
-    - name: Checkout gh-pages
-      uses: actions/checkout@v4
-      with:
-        ref: gh-pages
-        path: _web
-    - name: Set up MATLAB
-      uses: matlab-actions/setup-matlab@v2
-      with:
-        release: R2023b
-        cache: true
-    - name: Run script
-      uses: matlab-actions/run-command@v2
-      with:
-        command: disp("Hello World")
     - name: Set up Python 
       uses: actions/setup-python@v4
+      with:
+        python-version: '3.11' 
     - name: Install dependencies
       run: |
-        export LD_LIBRARY_PATH=/opt/hostedtoolcache/MATLAB/2023.2.999/x64/bin/glnxa64/:$LD_LIBARY_PATH
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     - name: Download MATLAB RAT
@@ -41,17 +26,19 @@ jobs:
         unzip Linux.zip -d API/
     - name: Build docs
       run: |
-        url=$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')
+        url="https://rascalsoftware.github.io/RAT-Docs/"
         echo -n ${url} > source/url.txt
         python build_docs.py
       env:
         GH_TOKEN: ${{ github.token }}
     - name: Checkout gh-pages
+      if: github.ref == 'refs/heads/main'
       uses: actions/checkout@v4
       with:
         ref: gh-pages
         path: _web
-    - name: Build and Deploy Docs
+    - name: Deploy Docs
+      if: github.ref == 'refs/heads/main'
       run: |
         python deploy.py ${{github.ref}}
         cd _web

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -21,6 +21,8 @@ jobs:
         path: _web
     - name: Set up MATLAB
       uses: matlab-actions/setup-matlab@v2
+      with:
+        release: R2024a
     - name: Set up Python 
       uses: actions/setup-python@v4
     - name: Install dependencies
@@ -33,7 +35,12 @@ jobs:
         wget https://github.com/RascalSoftware/RAT/releases/download/nightly/Linux.zip
         unzip Linux.zip -d API/
     - name: Build docs
-      run: python build_docs.py
+      run: |
+        url=$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')
+        echo -n ${url} > source/url.txt
+        python build_docs.py
+      env:
+        GH_TOKEN: ${{ github.token }}
     - name: Checkout gh-pages
       uses: actions/checkout@v4
       with:
@@ -41,10 +48,6 @@ jobs:
         path: _web
     - name: Build and Deploy Docs
       run: |
-        url=$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')
-        echo $url
-        echo $url > source/url.txt
-        make html
         python deploy.py ${{github.ref}}
         cd _web
         git config user.name github-actions
@@ -52,5 +55,4 @@ jobs:
         git add -A
         git commit -m "Publish Documentation" || true
         git push
-      env:
-        GH_TOKEN: ${{ github.token }}
+      

--- a/build_docs.py
+++ b/build_docs.py
@@ -6,8 +6,8 @@ from sphinx.application import Sphinx
 
 cur_dir = os.path.dirname(os.path.realpath(__file__))
 src_dir = os.path.join(cur_dir, "source") 
-build_dir = os.path.join(cur_dir, "build")
-doctree_dir = os.path.join(build_dir, "doctrees")
+build_dir = os.path.join(cur_dir, "build", "html")
+doctree_dir = os.path.join(cur_dir, "build", "doctrees")
 builder = "html"
 
 with tempfile.TemporaryDirectory() as tmp_dir, open(os.path.join(tmp_dir, "doc.txt"), "w+") as warning:

--- a/deploy.py
+++ b/deploy.py
@@ -2,7 +2,7 @@ import json
 import os
 import shutil
 from urllib.parse import urljoin
-from .version import get_doc_version
+from version import get_doc_version
 
 
 DOCS_PATH = os.path.abspath(os.path.dirname(__file__))

--- a/deploy.py
+++ b/deploy.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 import shutil
-import sys
 from urllib.parse import urljoin
 
 
@@ -12,24 +11,19 @@ VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
                            r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
 DOCS_PATH = os.path.abspath(os.path.dirname(__file__))
 VERSION_FILE = os.path.join(DOCS_PATH, 'API', 'version.txt')
-URL_FILE = os.path.join(DOCS_PATH, 'source', 'url.txt')
 
-url = ''
-with open(URL_FILE, 'r') as url_file:
-    url = url_file.read() 
+url = os.environ.get('RAT_URL', '') 
 
 doc_version = 'dev'
-# if version is present in argv use that instead 
-if len(sys.argv) > 1:
-    version = sys.argv[1].strip()
-else:
+version = os.environ.get('RAT_VERSION')
+if version is None:
     with open(VERSION_FILE, 'r') as version_file:
         version = version_file.read()
-
-if version != 'main':
-    print(version)
+    
+release = version
+if version != 'main':    
     major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
-    doc_version = f'{version[0]}.{version[1]}'
+    doc_version = f'{major}.{minor}'
 
 BUILD_PATH = os.path.join(DOCS_PATH, 'build', 'html')
 WEB_PATH = os.path.join(DOCS_PATH, '_web', doc_version)
@@ -57,8 +51,6 @@ INDEX_FILE = os.path.join(DOCS_PATH, '_web', 'index.html')
 is_latest = (len(releases) > 1 and releases[-2] == doc_version)
 base_url = urljoin(url, f'{doc_version}/')
 index_url = urljoin(base_url, 'index.html')
-print(base_url)
-print(index_url)
 if not os.path.exists(INDEX_FILE) or is_latest:
     
     data = [

--- a/deploy.py
+++ b/deploy.py
@@ -1,29 +1,14 @@
 import json
 import os
-import re
 import shutil
 from urllib.parse import urljoin
+from .version import get_doc_version
 
 
-VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-                           r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-                           r"(?:\.(?:0|[1-9]\d*|\d *[a-zA-Z-][0-9a-zA-Z-]*))*))?"
-                           r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
 DOCS_PATH = os.path.abspath(os.path.dirname(__file__))
-VERSION_FILE = os.path.join(DOCS_PATH, 'API', 'version.txt')
 
 url = os.environ.get('RAT_URL', '') 
-
-doc_version = 'dev'
-version = os.environ.get('RAT_VERSION')
-if version is None:
-    with open(VERSION_FILE, 'r') as version_file:
-        version = version_file.read()
-    
-release = version
-if version != 'main':    
-    major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
-    doc_version = f'{major}.{minor}'
+doc_version = get_doc_version()
 
 BUILD_PATH = os.path.join(DOCS_PATH, 'build', 'html')
 WEB_PATH = os.path.join(DOCS_PATH, '_web', doc_version)

--- a/deploy.py
+++ b/deploy.py
@@ -10,9 +10,13 @@ VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
                            r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
 DOCS_PATH = os.path.abspath(os.path.dirname(__file__))
 VERSION_FILE = os.path.join(DOCS_PATH, 'API', 'version.txt')
+URL_FILE = os.path.join(DOCS_PATH, 'source', 'url.txt')
+
+url = ''
+with open(URL_FILE, 'r') as url_file:
+    url = url_file.read() 
 
 doc_version = 'dev'
-
 with open(VERSION_FILE, 'r') as version_file:
     version = version_file.read()
     if os.environ.get('github.ref', 'main') != 'main':
@@ -29,27 +33,30 @@ shutil.copytree(BUILD_PATH, WEB_PATH, ignore=shutil.ignore_patterns('.buildinfo'
                                                                     '_sphinx_design_static'))
 
 releases = [entry.name for entry in os.scandir(os.path.join(DOCS_PATH, '_web')) if entry.is_dir() and entry.name != '.git']
+releases.sort()
 switch_list = []
 for release in releases:
     switch_list.append({'name': release, 
                         'version': release, 
-                        'url': f'https://rascalsoftware.github.io/RAT-Docs/{release}/'})
+                        'url': f'{url}/RAT-Docs/{release}/'})
 
 SWITCHER_FILE = os.path.join(DOCS_PATH, '_web', 'switcher.json')
 with open(SWITCHER_FILE, 'w') as switcher_file:
     json.dump(switch_list, switcher_file)
 
 INDEX_FILE = os.path.join(DOCS_PATH, '_web', 'index.html')
-if not os.path.exists(INDEX_FILE) or os.environ.get('github.ref', 'main') != 'main':
+
+is_latest = (len(releases) > 1 and releases[-2] == doc_version)
+if not os.path.exists(INDEX_FILE) or is_latest:
     
     data = [
         '<!DOCTYPE html>\n',
         '<html>\n',
         '  <head>\n',
-        f'    <title>Redirecting to https://rascalsoftware.github.io/RAT-Docs/{doc_version}/</title>\n',
+        f'    <title>Redirecting to {url}/RAT-Docs/{doc_version}/</title>\n',
         '    <meta charset="utf-8">\n',
-        f'    <meta http-equiv="refresh" content="0; URL=https://rascalsoftware.github.io/RAT-Docs/{doc_version}/index.html">\n',
-        f'    <link rel="canonical" href="https://rascalsoftware.github.io/RAT-Docs/{doc_version}/index.html">\n',
+        f'    <meta http-equiv="refresh" content="0; URL={url}/RAT-Docs/{doc_version}/index.html">\n',
+        f'    <link rel="canonical" href="{url}/RAT-Docs/{doc_version}/index.html">\n',
         '  </head>\n',
         '</html>',
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ sphinx_design==0.6.0
 sphinx-copybutton==0.5.2
 RATapi
 numpy
-matlabengine==24.1.*
+matlabengine==23.2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ sphinx_design==0.6.0
 sphinx-copybutton==0.5.2
 RATapi
 numpy
-matlabengine
+matlabengine==24.1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ pydata-sphinx-theme==0.15.2
 sphinx_design==0.6.0
 sphinx-copybutton==0.5.2
 RATapi
-numpy
-matlabengine==23.2.*
+matlabengine==24.1.*

--- a/source/conf.py
+++ b/source/conf.py
@@ -16,7 +16,8 @@ from urllib.parse import urljoin
 # ones.
 exclude_patterns = []
 current_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.abspath(os.path.join(current_dir, '..', 'API'))) # matlab src dir
+matlab_src_dir = os.path.abspath(os.path.join(current_dir, '..', 'API'))
+sys.path.insert(0, matlab_src_dir)
 
 import RATapi
 sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))

--- a/source/conf.py
+++ b/source/conf.py
@@ -30,7 +30,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))
 
 project = 'RAT'
 copyright = u'2022-{}, ISIS Neutron and Muon Source'.format(datetime.date.today().year)
-author = 'Arwel Hughes, Sethu Pastula, Rabiya Farooq, Paul Sharp, Stephen Nneji'
+author = 'Arwel Hughes, Sethu Pastula, Alex Room, Rabiya Farooq, Paul Sharp, Stephen Nneji'
 
 # The full version, including alpha/beta/rc tags
 VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
@@ -39,12 +39,15 @@ VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
                            r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
 
 doc_version = 'dev'
-with open(VERSION_FILE, 'r') as version_file:
-    version = version_file.read()
-    release = version
-    if os.environ.get('github.ref', 'main') != 'main':
-        major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
-        doc_version = f'{major}.{minor}'
+version = os.environ.get('RAT_VERSION')
+if version is None:
+    with open(VERSION_FILE, 'r') as version_file:
+        version = version_file.read()
+    
+release = version
+if version != 'main':    
+    major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
+    doc_version = f'{major}.{minor}'
     
 # -- General configuration ---------------------------------------------------
 
@@ -72,10 +75,8 @@ html_favicon = "_static/logo.png"
 html_static_path = ['_static']
 html_css_files = ["custom.css"]
 html_logo = '_static/logo.png'
-
-url = ''
-with open(URL_FILE, 'r') as url_file:
-    url = url_file.read()    
+ 
+url = os.environ.get('RAT_URL', '') 
         
 html_theme_options = {'show_prev_next': False,
                       'pygment_light_style': 'tango',

--- a/source/conf.py
+++ b/source/conf.py
@@ -16,8 +16,7 @@ from urllib.parse import urljoin
 # ones.
 exclude_patterns = []
 current_dir = os.path.dirname(os.path.abspath(__file__))
-matlab_src_dir = os.path.abspath(os.path.join(current_dir, '..', 'API'))
-sys.path.insert(0, matlab_src_dir)
+sys.path.insert(0, os.path.abspath(os.path.join(current_dir, '..', 'API'))) # matlab src dir
 
 import RATapi
 sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))

--- a/source/conf.py
+++ b/source/conf.py
@@ -21,7 +21,7 @@ sys.path.insert(0, os.path.abspath(".."))
 exclude_patterns = []
 current_dir = os.path.dirname(os.path.abspath(__file__))
 
-sys.path.insert(0, os.path.abspath(os.path.join(current_dir, '..', 'API')))  # matlab_src_dir 
+sys.path.insert(0, os.path.abspath(os.path.join(current_dir, '..', 'API')))  # matlab src dir 
 sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))
 
 project = 'RAT'

--- a/source/conf.py
+++ b/source/conf.py
@@ -23,7 +23,6 @@ current_dir = os.path.dirname(os.path.abspath(__file__))
 matlab_src_dir = os.path.abspath(os.path.join(current_dir, '..', 'API'))
 sys.path.insert(0, matlab_src_dir)
 VERSION_FILE = os.path.join(matlab_src_dir, 'version.txt')
-URL_FILE = os.path.join(current_dir, 'url.txt')
 
 import RATapi
 sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))
@@ -45,8 +44,9 @@ if version is None:
         version = version_file.read()
     
 release = version
-if version != 'main':    
-    major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
+tmp = VERSION_REGEX.match(version.replace(' ', ''))
+if tmp is not None:
+    major, minor, *other = list(tmp.groups())
     doc_version = f'{major}.{minor}'
     
 # -- General configuration ---------------------------------------------------

--- a/source/conf.py
+++ b/source/conf.py
@@ -13,8 +13,7 @@ import sys
 import datetime
 from urllib.parse import urljoin
 import RATapi
-from ..version import get_doc_version
-
+sys.path.insert(0, os.path.abspath(".."))
 # -- Project information -----------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -29,6 +28,7 @@ project = 'RAT'
 copyright = u'2022-{}, ISIS Neutron and Muon Source'.format(datetime.date.today().year)
 author = 'Arwel Hughes, Sethu Pastula, Alex Room, Rabiya Farooq, Paul Sharp, Stephen Nneji'
 
+from version import get_doc_version
 doc_version = get_doc_version()  
 release = doc_version
     

--- a/source/conf.py
+++ b/source/conf.py
@@ -12,6 +12,7 @@ import re
 import os
 import sys
 import datetime
+from urllib.parse import urljoin
 
 # -- Project information -----------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be
@@ -80,7 +81,7 @@ html_theme_options = {'show_prev_next': False,
                       'pygment_light_style': 'tango',
                       'pygment_dark_style': 'monokai',
                       'navbar_start': ['navbar-logo', 'version-switcher'],
-                      'switcher': {'json_url': f'{url}/switcher.json', 
+                      'switcher': {'json_url': urljoin(url, 'switcher.json'), 
                                    'version_match': doc_version,
                                    "check_switcher": False,},
                      }

--- a/source/conf.py
+++ b/source/conf.py
@@ -28,9 +28,9 @@ project = 'RAT'
 copyright = u'2022-{}, ISIS Neutron and Muon Source'.format(datetime.date.today().year)
 author = 'Arwel Hughes, Sethu Pastula, Alex Room, Rabiya Farooq, Paul Sharp, Stephen Nneji'
 
-sys.path.insert(0, os.path.abspath(".."))
-from version import get_doc_version
-doc_version = get_doc_version()  
+#sys.path.insert(0, os.path.abspath(".."))
+# from version import get_doc_version
+doc_version = "dev"#get_doc_version()  
 release = doc_version
     
 # -- General configuration ---------------------------------------------------

--- a/source/conf.py
+++ b/source/conf.py
@@ -38,8 +38,6 @@ if version is None:
         version = version_file.read()
 
 release = version
-if version != 'main':    
-    major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
 tmp = VERSION_REGEX.match(version.replace(' ', ''))
 if tmp is not None:
     major, minor, *other = list(tmp.groups())

--- a/source/conf.py
+++ b/source/conf.py
@@ -8,11 +8,12 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-import re
 import os
 import sys
 import datetime
 from urllib.parse import urljoin
+import RATapi
+from ..version import get_doc_version
 
 # -- Project information -----------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be
@@ -20,34 +21,16 @@ from urllib.parse import urljoin
 # ones.
 exclude_patterns = []
 current_dir = os.path.dirname(os.path.abspath(__file__))
-matlab_src_dir = os.path.abspath(os.path.join(current_dir, '..', 'API'))
-sys.path.insert(0, matlab_src_dir)
-VERSION_FILE = os.path.join(matlab_src_dir, 'version.txt')
 
-import RATapi
+sys.path.insert(0, os.path.abspath(os.path.join(current_dir, '..', 'API')))  # matlab_src_dir 
 sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))
 
 project = 'RAT'
 copyright = u'2022-{}, ISIS Neutron and Muon Source'.format(datetime.date.today().year)
 author = 'Arwel Hughes, Sethu Pastula, Alex Room, Rabiya Farooq, Paul Sharp, Stephen Nneji'
 
-# The full version, including alpha/beta/rc tags
-VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-                           r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-                           r"(?:\.(?:0|[1-9]\d*|\d *[a-zA-Z-][0-9a-zA-Z-]*))*))?"
-                           r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
-
-doc_version = 'dev'
-version = os.environ.get('RAT_VERSION')
-if version is None:
-    with open(VERSION_FILE, 'r') as version_file:
-        version = version_file.read()
-    
-release = version
-tmp = VERSION_REGEX.match(version.replace(' ', ''))
-if tmp is not None:
-    major, minor, *other = list(tmp.groups())
-    doc_version = f'{major}.{minor}'
+doc_version = get_doc_version()  
+release = doc_version
     
 # -- General configuration ---------------------------------------------------
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,31 +18,14 @@ exclude_patterns = []
 current_dir = os.path.dirname(os.path.abspath(__file__))
 matlab_src_dir = os.path.abspath(os.path.join(current_dir, '..', 'API'))
 sys.path.insert(0, matlab_src_dir)
-VERSION_FILE = os.path.join(matlab_src_dir, 'version.txt')
-URL_FILE = os.path.join(current_dir, 'url.txt')
 
 import RATapi
 sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))
 project = 'RAT'
 copyright = u'2022-{}, ISIS Neutron and Muon Source'.format(datetime.date.today().year)
 author = 'Arwel Hughes, Sethu Pastula, Alex Room, Rabiya Farooq, Paul Sharp, Stephen Nneji'
+
 # The full version, including alpha/beta/rc tags
-VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-                           r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-                           r"(?:\.(?:0|[1-9]\d*|\d *[a-zA-Z-][0-9a-zA-Z-]*))*))?"
-                           r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
-# doc_version = 'dev'
-# version = os.environ.get('RAT_VERSION')
-# if version is None:
-#     with open(VERSION_FILE, 'r') as version_file:
-#         version = version_file.read()
-
-# release = version
-# tmp = VERSION_REGEX.match(version.replace(' ', ''))
-# if tmp is not None:
-#     major, minor, *other = list(tmp.groups())
-#     doc_version = f'{major}.{minor}'
-
 sys.path.insert(0, os.path.dirname(os.path.abspath("..")))
 from version import get_doc_version
 doc_version = get_doc_version()

--- a/source/conf.py
+++ b/source/conf.py
@@ -21,6 +21,8 @@ exclude_patterns = []
 current_dir = os.path.dirname(os.path.abspath(__file__))
 matlab_src_dir = os.path.abspath(os.path.join(current_dir, '..', 'API'))
 sys.path.insert(0, matlab_src_dir)
+VERSION_FILE = os.path.join(matlab_src_dir, 'version.txt')
+URL_FILE = os.path.join(current_dir, 'url.txt')
 
 import RATapi
 sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))
@@ -34,7 +36,6 @@ VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
                            r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
                            r"(?:\.(?:0|[1-9]\d*|\d *[a-zA-Z-][0-9a-zA-Z-]*))*))?"
                            r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
-VERSION_FILE = os.path.join(matlab_src_dir, 'version.txt')
 
 doc_version = 'dev'
 with open(VERSION_FILE, 'r') as version_file:
@@ -69,13 +70,17 @@ bgcolor = 'white'
 html_favicon = "_static/logo.png"
 html_static_path = ['_static']
 html_css_files = ["custom.css"]
-
 html_logo = '_static/logo.png'
+
+url = ''
+with open(URL_FILE, 'r') as url_file:
+    url = url_file.read()    
+        
 html_theme_options = {'show_prev_next': False,
                       'pygment_light_style': 'tango',
                       'pygment_dark_style': 'monokai',
                       'navbar_start': ['navbar-logo', 'version-switcher'],
-                      'switcher': {'json_url': 'https://rascalsoftware.github.io/RAT-Docs/switcher.json', 
+                      'switcher': {'json_url': f'{url}/RAT-Docs/switcher.json', 
                                    'version_match': doc_version,
                                    "check_switcher": False,},
                      }

--- a/source/conf.py
+++ b/source/conf.py
@@ -13,7 +13,7 @@ import sys
 import datetime
 from urllib.parse import urljoin
 import RATapi
-sys.path.insert(0, os.path.abspath(".."))
+
 # -- Project information -----------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -28,6 +28,7 @@ project = 'RAT'
 copyright = u'2022-{}, ISIS Neutron and Muon Source'.format(datetime.date.today().year)
 author = 'Arwel Hughes, Sethu Pastula, Alex Room, Rabiya Farooq, Paul Sharp, Stephen Nneji'
 
+sys.path.insert(0, os.path.abspath(".."))
 from version import get_doc_version
 doc_version = get_doc_version()  
 release = doc_version

--- a/source/conf.py
+++ b/source/conf.py
@@ -80,7 +80,7 @@ html_theme_options = {'show_prev_next': False,
                       'pygment_light_style': 'tango',
                       'pygment_dark_style': 'monokai',
                       'navbar_start': ['navbar-logo', 'version-switcher'],
-                      'switcher': {'json_url': f'{url}/RAT-Docs/switcher.json', 
+                      'switcher': {'json_url': f'{url}/switcher.json', 
                                    'version_match': doc_version,
                                    "check_switcher": False,},
                      }

--- a/source/conf.py
+++ b/source/conf.py
@@ -1,37 +1,49 @@
-# Configuration file for the Sphinx documentation builder.
-#
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 # -- Path setup --------------------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
+import re
 import os
 import sys
 import datetime
 from urllib.parse import urljoin
-import RATapi
-
 # -- Project information -----------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 exclude_patterns = []
 current_dir = os.path.dirname(os.path.abspath(__file__))
+matlab_src_dir = os.path.abspath(os.path.join(current_dir, '..', 'API'))
+sys.path.insert(0, matlab_src_dir)
+VERSION_FILE = os.path.join(matlab_src_dir, 'version.txt')
+URL_FILE = os.path.join(current_dir, 'url.txt')
 
-sys.path.insert(0, os.path.abspath(os.path.join(current_dir, '..', 'API')))  # matlab src dir 
+import RATapi
 sys.path.insert(0, os.path.dirname(os.path.abspath(RATapi.__file__)))
-
 project = 'RAT'
 copyright = u'2022-{}, ISIS Neutron and Muon Source'.format(datetime.date.today().year)
 author = 'Arwel Hughes, Sethu Pastula, Alex Room, Rabiya Farooq, Paul Sharp, Stephen Nneji'
+# The full version, including alpha/beta/rc tags
+VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+                           r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+                           r"(?:\.(?:0|[1-9]\d*|\d *[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+                           r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
+doc_version = 'dev'
+version = os.environ.get('RAT_VERSION')
+if version is None:
+    with open(VERSION_FILE, 'r') as version_file:
+        version = version_file.read()
 
-#sys.path.insert(0, os.path.abspath(".."))
-# from version import get_doc_version
-doc_version = "dev"#get_doc_version()  
-release = doc_version
+release = version
+if version != 'main':    
+    major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
+tmp = VERSION_REGEX.match(version.replace(' ', ''))
+if tmp is not None:
+    major, minor, *other = list(tmp.groups())
+    doc_version = f'{major}.{minor}'
     
 # -- General configuration ---------------------------------------------------
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -31,17 +31,21 @@ VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
                            r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
                            r"(?:\.(?:0|[1-9]\d*|\d *[a-zA-Z-][0-9a-zA-Z-]*))*))?"
                            r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
-doc_version = 'dev'
-version = os.environ.get('RAT_VERSION')
-if version is None:
-    with open(VERSION_FILE, 'r') as version_file:
-        version = version_file.read()
+# doc_version = 'dev'
+# version = os.environ.get('RAT_VERSION')
+# if version is None:
+#     with open(VERSION_FILE, 'r') as version_file:
+#         version = version_file.read()
 
-release = version
-tmp = VERSION_REGEX.match(version.replace(' ', ''))
-if tmp is not None:
-    major, minor, *other = list(tmp.groups())
-    doc_version = f'{major}.{minor}'
+# release = version
+# tmp = VERSION_REGEX.match(version.replace(' ', ''))
+# if tmp is not None:
+#     major, minor, *other = list(tmp.groups())
+#     doc_version = f'{major}.{minor}'
+
+sys.path.insert(0, os.path.dirname(os.path.abspath("..")))
+from version import get_doc_version
+doc_version = get_doc_version()
     
 # -- General configuration ---------------------------------------------------
 

--- a/source/tutorial/chapter2.rst
+++ b/source/tutorial/chapter2.rst
@@ -196,7 +196,7 @@ To add a parameter, you can just specify a name, in which case the parameter tak
 .. tab-set-code::
     .. code-block:: Matlab
 
-        problem.addParameter('My new param');
+        problem.addParameter('My new param', 1, 2, 3);
         problem.addParameter('My other new param',10,20,30,false);
 
     .. code-block:: Python
@@ -234,7 +234,7 @@ The resulting parameters block looks like this:
 
         .. output:: Matlab
 
-            problem.addParameter('My new param');
+            problem.addParameter('My new param', 1, 2, 3);
             problem.addParameter('My other new param',10,20,30,false);
             pGroup = {{'Layer thick', 10, 20, 30, true};
                     {'Layer SLD', 1e-6, 3e-6 5e-6, true};
@@ -496,11 +496,17 @@ Our two layers now appear in the Layers block of the project:
         .. output:: Python
 
             problem = RAT.Project(name='Layers Example')
-            
+            params = [RAT.models.Parameter(name='Layer Thickness', min=10, value=20, max=30, fit=False),
+                    RAT.models.Parameter(name='H SLD', min=-6e-6, value=-4e-6, max=-1e-6, fit=False),
+                    RAT.models.Parameter(name='D SLD', min=5e-6, value=7e-6, max=9e-6, fit=True),
+                    RAT.models.Parameter(name='Layer rough', min=3, value=5, max=7, fit=True),
+                    RAT.models.Parameter(name='Layer hydr', min=0, value=10, max=20, fit=True)]
+            problem.parameters.extend(params)
+
             problem.layers.append(name='H Layer', thickness='Layer Thickness', SLD='H SLD',
-                              roughness='Layer rough', hydration='Layer hydr', hydrate_with='bulk out')
+                                roughness='Layer rough', hydration='Layer hydr', hydrate_with='bulk out')
             problem.layers.append(name='D Layer', thickness='Layer Thickness', SLD='D SLD',
-                              roughness='Layer rough', hydration='Layer hydr', hydrate_with='bulk out')
+                                roughness='Layer rough', hydration='Layer hydr', hydrate_with='bulk out')
 
             print(problem.layers)
 
@@ -1246,7 +1252,7 @@ Now we'll calculate this to check the agreement with the data. We need an instan
 
         .. output:: Matlab
 
-            controls.display = 'on';
+            controls.display = 'iter';
             disp(controls)
 
     .. tab-item:: Python 

--- a/version.py
+++ b/version.py
@@ -20,9 +20,10 @@ def get_doc_version():
         with open(VERSION_FILE, 'r') as version_file:
             version = version_file.read()
 
-    if version != 'main':    
-        major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
+    tmp = VERSION_REGEX.match(version.replace(' ', ''))
+    if tmp is not None:
+        major, minor, *other = list(tmp.groups())
         doc_version = f'{major}.{minor}'
-    
+        
     return doc_version
  

--- a/version.py
+++ b/version.py
@@ -1,0 +1,28 @@
+import os
+import re
+
+
+# The regex for major, minor and bugfix version, including alpha/beta/rc tags
+VERSION_REGEX = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+                           r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+                           r"(?:\.(?:0|[1-9]\d*|\d *[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+                           r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?")
+DOCS_PATH = os.path.abspath(os.path.dirname(__file__))
+VERSION_FILE = os.path.join(DOCS_PATH, 'API', 'version.txt')
+
+
+def get_doc_version():
+    """Grabs doc version from environment variable otherwise fallback to version 
+    file in RAT if not set"""
+    doc_version = 'dev'
+    version = os.environ.get('RAT_VERSION')
+    if version is None:
+        with open(VERSION_FILE, 'r') as version_file:
+            version = version_file.read()
+
+    if version != 'main':    
+        major, minor, *other = list(VERSION_REGEX.match(version.replace(' ', '')).groups())
+        doc_version = f'{major}.{minor}'
+    
+    return doc_version
+ 


### PR DESCRIPTION
This also sets up a self hosted runner as Matlab Engine does not work with the MATLAB license used by setup-matlab https://github.com/matlab-actions/setup-matlab/issues/22 GitHub action 