### PR TITLE
changed snippets extension to not require MATLAB engine

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -24,6 +24,7 @@ jobs:
         wget https://github.com/RascalSoftware/RAT/releases/download/nightly/Linux.zip
         unzip Linux.zip -d API/
         python -m pip install --upgrade pip
+        pip install matlabengine==24.1.*
         pip install -r requirements.txt
         pip install RATapi
         python build_docs.py

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install matlabengine==24.1.*
         if [ ${RAT_VERSION} == 'dev' ]; then
           wget https://github.com/RascalSoftware/RAT/releases/download/nightly/Linux.zip
           pip install RATapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ sphinxcontrib-matlabdomain==0.18
 pydata-sphinx-theme==0.15.2
 sphinx_design==0.6.0
 sphinx-copybutton==0.5.2
-matlabengine==24.1.*


### PR DESCRIPTION
the `snippets` extension used to generate MATLAB/Python outputs made building the docs require a MATLAB license. This PR changes it so if MATLAB engine is not installed, a warning is produced when you try to create a MATLAB snippet and the snippet is blank, but the docs still build successfully so users without a MATLAB license can still build the docs locally.