### PR TITLE
Reorganised chapter 1 of tutorial and removed references to problemDef

### DIFF
--- a/source/examples/DSPC_custom_XY.rst
+++ b/source/examples/DSPC_custom_XY.rst
@@ -7,7 +7,7 @@ This shows an example of using a :ref:`custom XY<customXYProfile>` model to anal
 Similar to :ref:`DSPC_Custom_Layers`, we can make use of the fact that the volumes, and of course the atomistic composition are known. So, 
 for lipid tails for example, then we can take a literature value for the tails volume, have a fittable parameter for the lipid area per molecule, and then the tail thickness will simply be 
 
-.. math:: Tail Thick = Tail Volume / Lipid APM.
+.. math:: \text{Tail Thick} = \frac{\text{Tail Volume}}{\text{Lipid APM}}.
 
 Since the volume is known, then the SLD of the tails is also obviously easily calculable.
 
@@ -75,11 +75,5 @@ This example can be run as a script or interactively using the instructions belo
 
 .. _ref_1:
 
-[1]  Sheker et al, J. Appl. Phys, 100, 102216 (2011) [|DOI|]
+[1]  Sheker et al, J. Appl. Phys, 100, 102216 (2011) [`DOI 10.1063/1.3661986 <https://doi.org/10.1063/1.3661986>`_]
 
-
-
-
-.. |DOI| raw:: html
-
-   <a href="https://doi.org/10.1063/1.3661986" target="_blank">DOI</a>

--- a/source/examples/custom_model_languages.rst
+++ b/source/examples/custom_model_languages.rst
@@ -19,7 +19,7 @@ This example can be run using the instructions below.
             **examples/miscellaneous/languages/alloyDomains.m**, 
             **examples/miscellaneous/languages/alloyDomains.m**. 
         
-        .. warning:: For Python custom functions, you will need to setup the python environment for MATLAB, see |PyEnv|
+        .. warning:: For Python custom functions, you will need to setup the python environment for MATLAB, see `Setup MATLAB to use Python <https://uk.mathworks.com/help/matlab/matlab_external/install-supported-python-implementation.html>`_
         
         **Run Script**: 
 
@@ -54,7 +54,3 @@ This example can be run using the instructions below.
             
             python RATapi.examples.languages.run_custom_file_languages.py
 
-
-.. |PyEnv| raw:: html
-
-   <a href="https://uk.mathworks.com/help/matlab/matlab_external/install-supported-python-implementation.html" target="_blank">Setup MATLAB to use Python</a>

--- a/source/index.rst
+++ b/source/index.rst
@@ -7,13 +7,13 @@
 
 Reflectivity Algorithms Toolbox (RAT) is a toolbox for analysing neutron reflectivity data at multiple contrasts.
 It has been designed as the calculation engine for the upcoming RasCAL-2,
-which will supersede the reflectivity software |RasCAL|. 
+which will supersede the reflectivity software `RasCAL <https://github.com/arwelHughes/RasCAL_2019>`_. 
 
 It is designed to be flexible, allowing analysis using traditional layer models,
 but also using user-defined custom models, which can be parameterised by the user however they wish
 (either as an array of layers, or a continuous SLD profile). 
 It is also incredibly fast; the core algorithm code is native C++, 
-created from the MATLAB source code using |MATLAB Coder|.
+created from the MATLAB source code using `MATLAB Coder <https://www.mathworks.com/products/matlab-coder.html>`_.
 
 By separating the GUI from the toolbox, users can create and run a full analysis from a script, 
 which can be written in either our MATLAB or Python API. 
@@ -63,7 +63,7 @@ RAT contains a number of improvements over legacy RasCAL, including:
         Get more help
         ^^^
 
-        The easiest way to get help with the project is to start discussions or open an issue on |Github|.
+        The easiest way to get help with the project is to start discussions or open an issue on `Github <https://github.com/RascalSoftware/RAT>`_.
 
 
 .. toctree::
@@ -79,15 +79,3 @@ RAT contains a number of improvements over legacy RasCAL, including:
    guide
    reference/matlab/index
 
-
-.. |Github| raw:: html
-
-   <a href="https://github.com/RascalSoftware/RAT" target="_blank">Github</a>
-
-.. |RasCAL| raw:: html
-
-   <a href="https://github.com/arwelHughes/RasCAL_2019" target="_blank">RasCAL</a>
-
-.. |MATLAB Coder| raw:: html
-
-   <a href="https://www.mathworks.com/products/matlab-coder.html" target="_blank">MATLAB Coder</a>

--- a/source/install.rst
+++ b/source/install.rst
@@ -34,7 +34,7 @@ This section provides more detailed information about installing RAT for MATLAB 
 
         To build the mex, do the following:
 
-        1. Download the RAT source code from the |release| page.
+        1. Download the RAT source code from the `Github release page <https://github.com/RascalSoftware/RAT/releases/latest>`_.
         2. Open MATLAB and navigate to the folder containing the RAT source code.
         3. Run *addPaths.m* then run *buildScript.m* in MATLAB. This will add the necessary paths and builds the MEX file. This could take several minutes depending on your machine.
         4. The MEX files will be created in the **RAT/compile** folder.
@@ -60,15 +60,6 @@ This section provides more detailed information about installing RAT for MATLAB 
 
         .. note::
             
-            MATLAB does not support every version of Python so you have to ensure to use a Python version that is supported by your installed MATLAB, 
-            for example, the maximum supported Python version for MATLAB 2023a is 3.10 so you cannot install matlabengine for this MATLAB on Python version 3.11 and above. 
-            You can check the |python_compatibility| on the MATLAB website.
+            MATLAB does not support every version of Python so you have to ensure to use a Python version that is supported by your installed MATLAB. 
+            You can check the `Python compatibility <https://mathworks.com/support/requirements/python-compatibility.html>`_ on the MATLAB website.
 
-
-.. |release| raw:: html
-
-   <a href="https://github.com/RascalSoftware/RAT/releases/latest" target="_blank">Github Release</a>
-
-.. |python_compatibility| raw:: html
-
-   <a href="https://mathworks.com/support/requirements/python-compatibility.html" target="_blank">Python Compatibility</a>

--- a/source/tutorial/chapter1.rst
+++ b/source/tutorial/chapter1.rst
@@ -4,48 +4,39 @@
 Introduction
 ============
 
-When we are at the calculations point our data analysis - that the data has been properly reduced, and we have some idea of a
-modelling strategy, we can still then split the problem specification into two parts.
+RAT is used to analyse reduced data; after an experiment has been performed and the raw data simplified into a more usable format
+(using a data reduction software such as `Mantid <https://docs.mantidproject.org/v4.2.0/techniques/ISIS_Reflectometry.html>`),
+we can use RAT for the calculation, estimation, and fitting of quantities of interest. 
 
-* The **Model Definition** describes our data, our model, the various parameters we may have along with their limits or priors,
+The central RAT workflow centres around two objects:
+
+* A **Definition** object (called a ``projectClass`` in MATLAB, ``Project`` in Python), which
+  describes our data, our models, the various parameters we may have along with their limits or priors,
   and other quantities such as bulk SLD's or backgrounds.
 
-* The **Controls Block** summarises the actions which we want to do with our model. So it specifies which algorithm we
-  might want to apply to improve our model fit, along with algorithm parameters such as maximum function evaluations or gradients etc.
+* A **Controls** object (``controlsClass`` in MATLAB, ``Controls`` in Python), which 
+  summarises the actions which we want to do with our model. It specifies which algorithm we
+  want to apply to improve our model fit, along with algorithm parameters such as maximum function evaluations, gradients, and parallelism options.
 
-Keeping these two separate gives a high degree of flexibility as to how we can approach a data analysis problem. For example,
-suppose we have defined a Model Definition block which contains the data and model details for a given fitting problem, we
-then decide that we would like to optimise this first using a genetic algorithm, and then run a Bayesian analysis to
-obtain the parameter posterior distributions. To do all this we only need to define our model once, and run it twice
-whilst simply modifying the Controls Block to tweak the algorithm that is run in each case. Also, once we are satisfied with
-our model, we can save it or export it, and re-use this basic pattern for subsequent analysis with different,
-related data sets. Keeping the Model and Controls separate gives a high degree of flexibility as to how tasks can be
-formulated and run.
+This decoupling is useful as it keeps the experimental model separate from the data analysis being performed upon it. Generally,
+one will define a single model and then run it with several different controls objects. For example, we may want to first optimise
+our parameter values for our model using a genetic algorithm, and then run a Bayesian analysis to obtain the posterior distributions
+for each parameter.
 
-So, an input into RAT always conforms to this picture: a model definition class to specify the problem, and a controls definition class that tells RAT what analysis task you would like to do:
+These inputs are passed into RAT (using the function ``RAT(project, controls)`` in MATLAB and ``run(project, controls)`` in Python) to produce
+two outputs. The first is a results object which contains the results of the calculations, such as simulated reflectivities, SLD profiles or parameter distributions.
+The second is another model definition, which describes the same experiment as the input definition but with updated best-fit parameter values for parameters which
+we have chosen to optimise.
+
+We will discuss these further in :ref:`the next chapter<chapter2>`, where we look at the inputs and outputs in more detail.
+
 
 .. image:: ../images/ratInput.png
-    :alt: RAT input model
-
-The outputs are always another *problemDef* class, and a results block. The new *problemDef* class is identical to the inputted one, except with updated values of the fitted parameters (e.g. after running a fit). The results block as a set of arrays containing the results of the calculations, such as simulated reflectivities, SLD profiles or parameter distributions. 
-We will discuss more about these in :ref:`next Section<chapter2>` where we look at the inputs and outputs in more detail.
-
-In the next section, we will look at an example calculation, in order to introduce the basics of the RAT toolbox. Before we proceed, it is useful to keep a couple of things in mind:
-
-
-* **Different model types** - There are many possible types of model, and this is done by having more than one version of
-    the *problemDef* class:
-
-    * Standard Problem: Problem types which are well described by a non-polarised beam, with no absorption (i.e., real refractive index only).
-    * Standard Problem with imaginary refractive index.
-    * Domains Problem Type ('incoherent summing').
-
-..  * *Oil/Water problem type (phase 2)*
-    * *Polarised problem type (phase 2)*
-
-Within each problem class, there is the option of *Custom Layer* or *Custom XY* model definitions. These will be discussed in more detail in a later section.
-
-In this section we'll look at the project definition class in more detail, we'll see how we can use the class methods to build and modify a model, and how to carry out the analysis.
+    :alt: A flowchart depicting the RAT workflow model described above. On the left, we have two boxes labeled Problem (Input) and Controls,
+          representing the required inputs used by RAT.
+          An arrow points from each of these boxes to a central box labeled 'RAT', which represents passing these input objects into
+          the main RAT program. Two arrows point from this central RAT box to a pair of boxes on the right labelled Problem (Output)
+          and Results, indicating the output produced by RAT after the program runs.
 
 .. note::
     If you are a RasCAL-1 user, you probably have existing RasCAL models that you would like to analyse using RAT. If so, there is no need to re-make the model from scratch. Instead, there are
@@ -56,31 +47,33 @@ In this section we'll look at the project definition class in more detail, we'll
 An example - A simple model of a lipid layer
 ********************************************
 
-**(a) Specifying the Model.**
+Specifying the Model
+--------------------
 
-In the next section, we'll look in detail how to set up the problem definition for a given situation. Initially though, it is
-useful to take a pre-prepared problem definition, and to see how this is then used in RAT. As an example, we'll use some
-neutron reflectivity data for a lipid monolayer, collected at various deuterations, which we want to analyse simultaneously.
+In :ref:`the next chapter<chapter2>`, we'll look in detail how to set up the problem definition for a given situation. 
+Here we will just use an existing example model to introduce how these objects are used in RAT.
+Our example data is neutron reflectivity data for a lipid monolayer (see image below), collected at various deuterations, 
+which we want to analyse simultaneously.
 
 In terms of reflectivity, the interface we want to model (i.e. a monolayer at an air-water interface) is usually well modelled
-by two layers: the hydrophobic tail regions of the lipids, which locate outside the bulk water interface, and the hydrophilic
+by two layers: the hydrophobic tail regions of the lipids, which are outside the bulk water interface, and the hydrophilic
 heads which are adjacent (or embedded) in the bulk aqueous phase.
 
-In our example, the layers can be either deuterated of hydrogenated, and the bulk water can either be D2O or ACMW.
+In our example, the layers can be either deuterated or hydrogenated, and the bulk water can either be D2O or ACMW.
 
 .. image:: ../images/userManual/chapter1/lipidMonolayer.png
     :width: 300
     :alt: The lipid monolayer example
 
-We are going to analyze our monolayer data using a RasCAL type *standard layers* model, in that we identify which parameters we
-need to describe the model, group these into layers (which are defined as a thickness, roughness, SLD and hydration), and then
-group the layers along with data into contrasts. The advantage of this approach is that it is simple to share parameters between
-layers, so a layer representing deuterated headgroups should share the same thickness and roughness parameters as a
-layer representing hydrogenated heads, but they should differ from each other in their SLD.
+We are going to analyze our monolayer data using a standard `slab model <https://www.reflectometry.org/learn/3_reflectometry_slab_models/the_slab_model.html>`.
+In this model, we approximate our experimental model as a series of layers with a known thickness, roughness, SLD and hydration.
+The way that this is represented in the RAT model definition is by a list of 'parameter' objects which represent a given quantity (such as a thickness or SLD),
+and then a list of 'layer' objects which group together these parameters to describe each layer. Layers are then grouped together in a 'contrast' object which
+describes the slab model and matches it up to the experimental data to which the model will be compared. In this project we have two contrasts representing
+two slab models (one for our deuterated experiment, one for our hydrogenated experiment).
 
-The problem definition in RAT is done by making an instance of a project class object, and then using the class methods to
-set up the parameters, layers and so on this instance. The details of setting up a *projectClass* object is
-discussed in :ref:`next Section<chapter2>`, but for now, we'll look at a pre-prepared example.
+The code output below gives the full contents of a model definition for our experiment. After seeing it in full, we will break down each section of this
+definition and explain what it describes.
 
 .. tab-set-code::
     .. code-block:: Matlab
@@ -126,14 +119,8 @@ discussed in :ref:`next Section<chapter2>`, but for now, we'll look at a pre-pre
             problem = locals['problem']
             print(problem)
 
-This may initially look quite complicated, but it is fairly self-explanatory in terms of representing a typical RasCAL
-model (and should make sense to anyone familiar to the RasCAL gui, with some thought). The various aspects of the model
-definition are grouped together, then eventually combined to make our contrasts. These groups are:
-
-1. **The Parameters Group -** This block defines all the parameters that we need to specify our model. In our layers case, we
-need 10 parameters to define our system: A bulk interface roughness, thickness and roughness for the headgroups and tails, and
-SLD values for the layers, depending on whether they are deuterated or not. In this block we also define the parameter values
-and their allowed ranges, and specify if they are included in the fit:-
+1. The Parameters Group
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. tab-set::
     :class: tab-label-hidden
@@ -153,9 +140,16 @@ and their allowed ranges, and specify if they are included in the fit:-
 
             print(problem.parameters)
 
-2. **The Layers Group -** Once we have our parameters, we then need to group these into layers, in traditional RasCAL style.
-For our model, we always have two layers - a headgroup and the associated tails. Each of which can be deuterated, so we set up
-4 layers in total, sharing the parameters between the layers as necessary:
+This block defines all the parameters that we need to specify our slab models. In our layers case, we
+need 10 parameters to define our system: A bulk interface roughness, thickness and roughness for the headgroups and tails, and
+SLD values for the layers, depending on whether they are deuterated or not. Each parameter has a given ``value``, a ``fit`` field
+which specifies whether they are included in the fitting algorithm, and ``min`` and ``max`` values indicating the minimum and maximum
+value they can take in a fit respectively. There are also ``prior_type``, ``mu``, and ``sigma`` fields which are used in Bayesian algorithms
+to leverage prior knowledge about the model, but for non-Bayesian algorithms these fields are ignored. We will not use them here.
+
+
+2. The Layers Group
+^^^^^^^^^^^^^^^^^^^
 
 .. tab-set::
     :class: tab-label-hidden
@@ -175,15 +169,22 @@ For our model, we always have two layers - a headgroup and the associated tails.
 
             print(problem.layers)
 
-3. **'Instrument' Parameters: (Backgrounds, scalefactors and resolutions) -** These are necessary to specify our model, and are 
-specified in much the same way as the parameters. The background and resolutions blocks have a more complicated format to allow 
-flexibility in how these are specified, which will be discussed further in a later section. These are the parameters that appear 
-in the *experimental Parameters* tab of the RasCAL model builder, and are subsequently included in the definitions of the contrasts 
-at the end of the worksheet.
+Once we have our parameters, we then need to group these into layers. We have two slab models, each of which consists of a head
+and a tail at different deuteration levels. This means we require 4 layers total. 
 
-4. **Data -** Each contrast has to have a dataset associated with it, whether or not it contains data or not. An empty data object 
-(i.e. containing no data and just simulation ranges), means RAT will calculate the reflectivity only. When data is present, chi-squared 
-will also be calculated. For our problem, we have two datasets and these are coded in to the data block ready to be incorporated into contrasts:
+3. 'Instrument' Parameters: (Backgrounds, scalefactors and resolutions)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The tables for scalefactors, backgrounds, resolutions and parameters thereof describe 
+parameters which are not directly part of our model, but part of our experiment, such as 
+the background or resolution of the instrument, or scale factors to fix systemic errors in scaling 
+(with respect to absolute reflectivity). We will not discuss these in detail here, but we will note
+that background parameters, resolution parameters and scalefactors are parameters just like the ones above,
+and can be fit in the same way as part of our analysis (e.g. if the scalefactor is unknown and we would like to optimise it)!
+
+
+4. Data
+^^^^^^^
 
 .. tab-set::
     :class: tab-label-hidden
@@ -203,7 +204,14 @@ will also be calculated. For our problem, we have two datasets and these are cod
 
             print(problem.data)
 
-5. **Contrasts -** Once we have defined all the components of our model, we need to group them together into contrasts. We have two datasets 
+Each contrast must have a dataset associated with it, whether or not it contains data or not. An empty data object 
+(i.e. containing no data and just simulation ranges) means RAT will calculate the reflectivity only. When data is present, chi-squared goodness of fit
+will also be calculated. For our problem, we have two datasets and these are passed to the data block ready to be incorporated into contrasts:
+
+5. Contrasts
+^^^^^^^^^^^^
+
+Once we have defined all the components of our model, we need to group them together into contrasts. We have two datasets 
 we want to consider, so two contrasts. We have the relevant instrument parameters, and also we specify which layers are included in each contrast (*model*). 
 
 .. tab-set::
@@ -224,11 +232,12 @@ we want to consider, so two contrasts. We have the relevant instrument parameter
             
             print(problem.contrasts)
 
-**(b) Running our Model.**
+Running the Model
+-----------------
 
-As implied from figure (1), running RAT requires not only our input model specification, but also a controls block telling RAT what to do. We 
-will discuss the controls block in more detail in :ref:`controlsInfo`, but for this demo we will just make an instance 
-of the controls block and modify a few parameters to run the demo:
+As we discussed at the beginning of the chapter, 
+More detail on the controls object is available at :ref:`controlsInfo`, 
+but for this demo we will just make an instance of the controls object:
 
 .. tab-set-code::
     .. code-block:: Matlab
@@ -263,10 +272,9 @@ of the controls block and modify a few parameters to run the demo:
             controls = RAT.Controls()
             print(controls)
 
-This makes an instance of the controls Class we have called **controls**. The various properties of the class allow the type of calculation 
-to be specified, in terms of parallelisation, choice of algorithm to be applied and so on. Here we are specifying a single threaded calculation 
-of our reflectivities only (the default) - in other words we are not asking RAT to do any kind of fit with our parameters. We can now send our 
-problem definition and controls classes to the RAT toolbox:
+By default, the Controls object specifies to run an `Abelès calculation <https://www.reflectometry.org/learn/3_reflectometry_slab_models/how_we_calculate_the_reflectivity_of_a_slab_model.html>`
+of the reflectivity for the model, and then uses that to calculate SLD profiles. In other words we are not asking RAT to do any kind of fit with our parameters. 
+We can now pass our problem definition and controls classes to the RAT toolbox to run the calculation:
 
 
 .. tab-set-code::
@@ -298,12 +306,11 @@ problem definition and controls classes to the RAT toolbox:
 
             problem, results = RAT.run(problem, controls)
 
-It is worth noticing here that this is always the general format for calling RAT. There are two inputs - a problem definition and a controls block, and the result is two outputs - another copy of the problem, and a new, *results* block. 
+Here, we overwrite our original input class with the output by using the same variable name (``problem``) as an input and an output, 
+but you don’t have to do it this way.
 
-The problem that returns is a copy of our input, except that the parameter values will be changed by any procedure done. So, if we run a simple fit, then the output *problemDef* will have the values of the best-fit parameters. Here, we are not doing any fitting yet, and so the output is an exact copy. Also, we overwrite our original input class with the output by using the same name ('problem') as an input and an output, but you don’t have to do it this way.
-
-Once we've run our model through RAT, then the second output (we call *results* here) is an array which contains the output of the calculation :
-
+As discussed above, the output of this run is an updated model definition (which in this case is completely identical to the input
+definition as we did not perform any fitting) as well as the results from our calculation. The results contain various output arrays:
 
 .. tab-set::
     :class: tab-label-hidden
@@ -324,7 +331,8 @@ Once we've run our model through RAT, then the second output (we call *results* 
 
             print(results)
 
-This contains the results of our calculations, so for us including the SLD profiles and reflectivities calculated from our *problemDef* class. We can now plot the output, either manually (by taking the relevant parts from the *results* array), or using one of the supplied plotting utilities:
+This contains the results of our calculations, so for us including the SLD profiles and reflectivities calculated from our problem class. 
+We can now plot the output, either manually (by taking the relevant parts from the ``results`` array), or using one of the supplied plotting utilities:
 
 .. tab-set-code::
     .. code-block:: Matlab
@@ -339,10 +347,5 @@ This contains the results of our calculations, so for us including the SLD profi
 .. image:: ../images/userManual/chapter1/plots.png
     :alt: reflectivity and SLD plots
 
-We can see that our model is looking fairly sensible, but that our guess values for the parameters are pretty wide off the mark.
-
-
-
-
-
-
+We can see that our model is looking fairly sensible, but that our guess values for the parameters are pretty wide off the mark. Further analysis
+might include running a fit over some of our parameters using one of the other procedures available in the controls object.

--- a/source/tutorial/chapter1.rst
+++ b/source/tutorial/chapter1.rst
@@ -10,11 +10,11 @@ we can use RAT for the calculation, estimation, and fitting of quantities of int
 
 The central RAT workflow centres around two objects:
 
-* A **Definition** object (called a ``projectClass`` in MATLAB, ``Project`` in Python), which
+* A **Project** object, which
   describes our data, our models, the various parameters we may have along with their limits or priors,
   and other quantities such as bulk SLD's or backgrounds.
 
-* A **Controls** object (``controlsClass`` in MATLAB, ``Controls`` in Python), which 
+* A **Controls** object, which 
   summarises the actions which we want to do with our model. It specifies which algorithm we
   want to apply to improve our model fit, along with algorithm parameters such as maximum function evaluations, gradients, and parallelism options.
 
@@ -23,7 +23,7 @@ one will define a single model and then run it with several different controls o
 our parameter values for our model using a genetic algorithm, and then run a Bayesian analysis to obtain the posterior distributions
 for each parameter.
 
-These inputs are passed into RAT (using the function ``RAT(project, controls)`` in MATLAB and ``run(project, controls)`` in Python) to produce
+These inputs are passed into RAT to produce
 two outputs. The first is a results object which contains the results of the calculations, such as simulated reflectivities, SLD profiles or parameter distributions.
 The second is another model definition, which describes the same experiment as the input definition but with updated best-fit parameter values for parameters which
 we have chosen to optimise.
@@ -37,6 +37,31 @@ We will discuss these further in :ref:`the next chapter<chapter2>`, where we loo
           An arrow points from each of these boxes to a central box labeled 'RAT', which represents passing these input objects into
           the main RAT program. Two arrows point from this central RAT box to a pair of boxes on the right labelled Problem (Output)
           and Results, indicating the output produced by RAT after the program runs.
+
+
+The below code block gives the name of each object for each language, as well as how to run a calculation.
+
+.. tab-set-code::
+    .. code-block:: Matlab
+
+        % to create a project and controls:
+        project = projectClass();
+        controls = controlsClass();
+        
+        % to run:
+        [project, results] = RAT(project, controls);
+
+    .. code-block:: Python
+
+        import RATapi as RAT
+
+        # to create a project and controls:
+        project = RAT.Project()
+        controls = RAT.Controls()
+
+        # to run:
+        project, results = RAT.run(project, controls)
+
 
 .. note::
     If you are a RasCAL-1 user, you probably have existing RasCAL models that you would like to analyse using RAT. If so, there is no need to re-make the model from scratch. Instead, there are
@@ -237,7 +262,7 @@ Running the Model
 
 As we discussed at the beginning of the chapter, the other input to RAT is a controls object,
 which describes the data analysis operation to use and any relevant settings such as 
-algorithm hyperparameters, parallelism, and display settings.
+algorithm-specific parameters, parallelism, and display settings.
 More detail on the controls object is available at :ref:`controlsInfo`, 
 but for this demo we will just make an instance of the controls object:
 

--- a/source/tutorial/chapter1.rst
+++ b/source/tutorial/chapter1.rst
@@ -235,7 +235,9 @@ we want to consider, so two contrasts. We have the relevant instrument parameter
 Running the Model
 -----------------
 
-As we discussed at the beginning of the chapter, 
+As we discussed at the beginning of the chapter, the other input to RAT is a controls object,
+which describes the data analysis operation to use and any relevant settings such as 
+algorithm hyperparameters, parallelism, and display settings.
 More detail on the controls object is available at :ref:`controlsInfo`, 
 but for this demo we will just make an instance of the controls object:
 

--- a/source/tutorial/chapter1.rst
+++ b/source/tutorial/chapter1.rst
@@ -5,7 +5,7 @@ Introduction
 ============
 
 RAT is used to analyse reduced data; after an experiment has been performed and the raw data simplified into a more usable format
-(using a data reduction software such as `Mantid <https://docs.mantidproject.org/v4.2.0/techniques/ISIS_Reflectometry.html>`),
+(using a data reduction software such as `Mantid <https://docs.mantidproject.org/v4.2.0/techniques/ISIS_Reflectometry.html>`_),
 we can use RAT for the calculation, estimation, and fitting of quantities of interest. 
 
 The central RAT workflow centres around two objects:
@@ -90,7 +90,7 @@ In our example, the layers can be either deuterated or hydrogenated, and the bul
     :width: 300
     :alt: The lipid monolayer example
 
-We are going to analyze our monolayer data using a standard `slab model <https://www.reflectometry.org/learn/3_reflectometry_slab_models/the_slab_model.html>`.
+We are going to analyze our monolayer data using a standard `slab model <https://www.reflectometry.org/learn/3_reflectometry_slab_models/the_slab_model.html>`_.
 In this model, we approximate our experimental model as a series of layers with a known thickness, roughness, SLD and hydration.
 The way that this is represented in the RAT model definition is by a list of 'parameter' objects which represent a given quantity (such as a thickness or SLD),
 and then a list of 'layer' objects which group together these parameters to describe each layer. Layers are then grouped together in a 'contrast' object which
@@ -299,7 +299,7 @@ but for this demo we will just make an instance of the controls object:
             controls = RAT.Controls()
             print(controls)
 
-By default, the Controls object specifies to run an `Abelès calculation <https://www.reflectometry.org/learn/3_reflectometry_slab_models/how_we_calculate_the_reflectivity_of_a_slab_model.html>`
+By default, the Controls object specifies to run an `Abelès calculation <https://www.reflectometry.org/learn/3_reflectometry_slab_models/how_we_calculate_the_reflectivity_of_a_slab_model.html>`_
 of the reflectivity for the model, and then uses that to calculate SLD profiles. In other words we are not asking RAT to do any kind of fit with our parameters. 
 We can now pass our problem definition and controls classes to the RAT toolbox to run the calculation:
 


### PR DESCRIPTION
Chapter 1 of the tutorial contained a few references to a `problemDef` class which no longer exists. I also reorganised and rewrote some of the text of chapter 1 to flow a little better and explain things in better detail, especially for users who may not be familiar with the data analysis we are doing or with RasCAL-1. I also removed a few instances where the tutorial text repeated itself, and fixed some typos.
