### PR TITLE
Updates to RATapi v0.0.0dev4

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,7 +26,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install matlabengine==24.1.*
         pip install -r requirements.txt
-        pip install RATapi
         python build_docs.py
     - name: Checkout gh-pages
       if: github.ref == 'refs/heads/main'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinxcontrib-matlabdomain==0.18
 pydata-sphinx-theme==0.15.2
 sphinx_design==0.6.0
 sphinx-copybutton==0.5.2
+RATapi==0.0.0.dev4

--- a/source/examples/DSPC_custom_XY.rst
+++ b/source/examples/DSPC_custom_XY.rst
@@ -50,27 +50,27 @@ This example can be run as a script or interactively using the instructions belo
     .. tab-item:: Python 
         :sync: Python
 
-        .. note:: The custom model used is a Python model - **RATapi.examples.non_polarised.custom_XY_DSPC.py**.
+        .. note:: The custom model used is a Python model - **RATapi.examples.normal_reflectivity.custom_XY_DSPC.py**.
 
 
         **Run Script**:  
         
         .. code-block:: console 
             
-            python RATapi.examples.non_polarised.DSPC_custom_XY.py
+            python RATapi.examples.normal_reflectivity.DSPC_custom_XY.py
 
         **Run as Function**:  
         
         .. code-block:: Python 
             
             import RATapi as RAT
-            problem, results = RAT.examples.non_polarised.DSPC_custom_XY()
+            problem, results = RAT.examples.normal_reflectivity.DSPC_custom_XY()
         
         **Run Interactively**:  
         
         .. code-block:: console 
             
-            jupyter notebook RATapi.examples.non_polarised.DSPC_custom_XY.ipynb
+            jupyter notebook RATapi.examples.normal_reflectivity.DSPC_custom_XY.ipynb
 
 
 .. _ref_1:

--- a/source/examples/DSPC_custom_layers.rst
+++ b/source/examples/DSPC_custom_layers.rst
@@ -45,23 +45,23 @@ This example can be run as a script or interactively using the instructions belo
     .. tab-item:: Python 
         :sync: Python
 
-        .. note:: The custom model used is a Python model - **RATapi.examples.non_polarised.custom_bilayer_DSPC.py**.
+        .. note:: The custom model used is a Python model - **RATapi.examples.normal_reflectivity.custom_bilayer_DSPC.py**.
 
         **Run Script**:  
         
         .. code-block:: console 
             
-            python RATapi.examples.non_polarised.DSPC_custom_layers.py
+            python RATapi.examples.normal_reflectivity.DSPC_custom_layers.py
 
         **Run as Function**:  
         
         .. code-block:: Python 
             
             import RATapi as RAT
-            problem, results = RAT.examples.non_polarised.DSPC_custom_layers()
+            problem, results = RAT.examples.normal_reflectivity.DSPC_custom_layers()
         
         **Run Interactively**:  
         
         .. code-block:: console 
             
-            jupyter notebook RATapi.examples.non_polarised.DSPC_custom_layers.ipynb
+            jupyter notebook RATapi.examples.normal_reflectivity.DSPC_custom_layers.ipynb

--- a/source/examples/DSPC_standard_layers.rst
+++ b/source/examples/DSPC_standard_layers.rst
@@ -39,17 +39,17 @@ This example can be run as a script or interactively using the instructions belo
         
         .. code-block:: console 
             
-            python RATapi.examples.non_polarised.DSPC_standard_layers.py
+            python RATapi.examples.normal_reflectivity.DSPC_standard_layers.py
 
         **Run as Function**:  
         
         .. code-block:: Python 
             
             import RATapi as RAT
-            problem, results = RAT.examples.non_polarised.DSPC_standard_layers()
+            problem, results = RAT.examples.normal_reflectivity.DSPC_standard_layers()
         
         **Run Interactively**:  
         
         .. code-block:: console 
             
-            jupyter notebook RATapi.examples.non_polarised.DSPC_standard_layers.ipynb
+            jupyter notebook RATapi.examples.normal_reflectivity.DSPC_standard_layers.ipynb

--- a/source/reference/matlab/projectClass.rst
+++ b/source/reference/matlab/projectClass.rst
@@ -54,7 +54,7 @@ Although, Project class provides one level higher interface so that one can use 
 *************
 Domains Class
 *************
-RAT currently supports two calculation types (nonPolarised and Domains). The Domains Class is a project class with extra parameters (domainRatio, domainContrasts) for the Domains calculation.
+RAT currently supports two calculation types (normal and Domains). The Domains Class is a project class with extra parameters (domainRatio, domainContrasts) for the Domains calculation.
 
 .. note::
     It is recommended to use `API.createProject` instead of creating a Project or Domains object directly.

--- a/source/reference/matlab/targetFunctions.rst
+++ b/source/reference/matlab/targetFunctions.rst
@@ -18,7 +18,7 @@ Common Functions
 .. automodule:: targetFunctions.common.groupLayers
     :members:    
 
-.. _nonPolarisedTF:
+.. _normalTF:
 
 Normal Target Functions (normalTF)
 

--- a/source/tutorial/chapter2.rst
+++ b/source/tutorial/chapter2.rst
@@ -700,7 +700,7 @@ The backgrounds can be one of three types: 'constant', 'function' or 'data'. The
     .. code-block:: Python
 
         problem.background_parameters.append(name='My New BackPar', min=1e-8, value=1e-7, max=1e-6, fit=True)
-        problem.backgrounds.append(name='My New Background', type='constant', value_1='My New BackPar')
+        problem.backgrounds.append(name='My New Background', type='constant', source='My New BackPar')
 
 
 With this code snippet we've made a new background, with the value taken from the (fittable) parameter called 'My New BackPar':
@@ -724,7 +724,7 @@ With this code snippet we've made a new background, with the value taken from th
         .. output:: Python
 
             problem.background_parameters.append(name='My New BackPar', min=1e-8, value=1e-7, max=1e-6, fit=True)
-            problem.backgrounds.append(name='My New Background', type='constant', value_1='My New BackPar')
+            problem.backgrounds.append(name='My New Background', type='constant', source='My New BackPar')
             print(problem.background_parameters)
             print(problem.backgrounds)
 
@@ -740,7 +740,7 @@ This is then available to be used by any of our contrasts (see later).
     
     .. code-block:: Python
 
-        problem.backgrounds.append(name='Data Background 1', type='data', value_1='My Background Data')
+        problem.backgrounds.append(name='Data Background 1', type='data', source='My Background Data')
 
 .. .. tab-set::
 ..     :class: tab-label-hidden
@@ -759,7 +759,7 @@ This is then available to be used by any of our contrasts (see later).
 
 ..         .. output:: Python
 
-..              problem.backgrounds.append(name='Data Background 1', type='data', value_1='My Background Data')
+..              problem.backgrounds.append(name='Data Background 1', type='data', source='My Background Data')
 ..              print(problem.backgrounds)
 
 This is then used in the reflectivity calculation for any contrast in which it is specified.
@@ -822,7 +822,7 @@ Then, we make the actual resolution referring to whichever one of the resolution
 
     .. code-block:: Python
     
-        problem.resolutions.append(name='My new resolution', type='constant', value_1='My Resolution Param')
+        problem.resolutions.append(name='My new resolution', type='constant', source='My Resolution Param')
         problem.resolutions.append(name='My Data Resolution', type='data')
 
 .. tab-set::
@@ -845,7 +845,7 @@ Then, we make the actual resolution referring to whichever one of the resolution
         .. output:: Python
 
             problem.resolution_parameters.append(name='My Resolution Param', min=0.02, value=0.05, max=0.08, fit=True)
-            problem.resolutions.append(name='My new resolution', type='constant', value_1='My Resolution Param')
+            problem.resolutions.append(name='My new resolution', type='constant', source='My Resolution Param')
             problem.resolutions.append(name='My Data Resolution', type='data')
             print(problem.resolutions)
 
@@ -1102,8 +1102,8 @@ Use these parameters to define two constant backgrounds, again using the existin
     
     .. code-block:: Python
 
-        problem.backgrounds.append(name='Background D2O', type='constant', value_1='Backs Value D2O')
-        problem.backgrounds.set_fields(0, name='Background ACMW', value_1='Backs Value ACMW')
+        problem.backgrounds.append(name='Background D2O', type='constant', source='Backs Value D2O')
+        problem.backgrounds.set_fields(0, name='Background ACMW', source='Backs Value ACMW')
 
 We need two sub-phases for our project. D2O is already in the project as a default, so we only need to add the bulk out for ACMW
 

--- a/source/tutorial/customModels.rst
+++ b/source/tutorial/customModels.rst
@@ -605,11 +605,11 @@ The rest of the custom model is defined similar to the standard layers model sho
         problem.background_parameters.append(name='Background parameter H2O', min=1.0e-10, value=1.0e-7, max=1.0e-5, fit=True)
 
         # And add the two new constant backgrounds
-        problem.backgrounds.append(name='Background SMW', type='constant', value_1='Background parameter SMW')
-        problem.backgrounds.append(name='Background H2O', type='constant', value_1='Background parameter H2O')
+        problem.backgrounds.append(name='Background SMW', type='constant', source='Background parameter SMW')
+        problem.backgrounds.append(name='Background H2O', type='constant', source='Background parameter H2O')
 
         # And edit the other one....
-        problem.backgrounds.set_fields(0, name='Background D2O', value_1='Background parameter D2O')
+        problem.backgrounds.set_fields(0, name='Background D2O', source='Background parameter D2O')
 
         # Finally modify some of the other parameters to be more suitable values for a solid / liquid experiment
         problem.scalefactors.set_fields(0, value=1.0, min=0.5, max=2.0, fit=True)

--- a/source/tutorial/data/two_contrast_example.py
+++ b/source/tutorial/data/two_contrast_example.py
@@ -34,8 +34,8 @@ problem.background_parameters.set_fields(0, name='Backs Value ACMW')
 problem.background_parameters.set_fields(0, value=5.5e-6)
 problem.background_parameters.append(name='Backs Value D2O', min=1e-8, value=2.8e-6, max=1e-5)
 
-problem.backgrounds.append(name='Background D2O', type='constant', value_1='Backs Value D2O')
-problem.backgrounds.set_fields(0, name='Background ACMW', value_1='Backs Value ACMW')
+problem.backgrounds.append(name='Background D2O', type='constant', source='Backs Value D2O')
+problem.backgrounds.set_fields(0, name='Background ACMW', source='Backs Value ACMW')
 
 problem.bulk_out.append(name='SLD ACMW', min=-0.6e-6, value=-0.56e-6, max=-0.3e-6, fit=True)
 

--- a/source/tutorial/savingAndClasses.rst
+++ b/source/tutorial/savingAndClasses.rst
@@ -212,8 +212,8 @@ Then, RAT will create a file containing all the statements needed to re-create y
             bulk_in=RAT.ClassList([RAT.models.Parameter(name='SLD Air', min=0.0, value=0.0, max=0.0, fit=False, prior_type='uniform', mu=0.0, sigma=inf)]),
             bulk_out=RAT.ClassList([RAT.models.Parameter(name='SLD D2O', min=6.2e-06, value=6.35e-06, max=6.35e-06, fit=False, prior_type='uniform', mu=0.0, sigma=inf)]),
             resolution_parameters=RAT.ClassList([RAT.models.Parameter(name='Resolution Param 1', min=0.01, value=0.03, max=0.05, fit=False, prior_type='uniform', mu=0.0, sigma=inf)]),
-            backgrounds=RAT.ClassList([Background(name='Background 1', type='constant', value_1='Background Param 1', value_2='', value_3='', value_4='', value_5='')]),
-            resolutions=RAT.ClassList([Resolution(name='Resolution 1', type='constant', value_1='Resolution Param 1', value_2='', value_3='', value_4='', value_5='')]),
+            backgrounds=RAT.ClassList([Background(name='Background 1', type='constant', source='Background Param 1', value_2='', value_3='', value_4='', value_5='')]),
+            resolutions=RAT.ClassList([Resolution(name='Resolution 1', type='constant', source='Resolution Param 1', value_2='', value_3='', value_4='', value_5='')]),
             data=RAT.ClassList([Data(name='Simulation')]),
             )
 

--- a/source/tutorial/savingAndClasses.rst
+++ b/source/tutorial/savingAndClasses.rst
@@ -205,7 +205,7 @@ Then, RAT will create a file containing all the statements needed to re-create y
         from numpy import array, inf
 
         problem = RAT.Project(
-            name='', calculation='non polarised', model='standard layers', geometry='air/substrate', absorption=False,
+            name='', calculation='normal', model='standard layers', geometry='air/substrate', absorption=False,
             parameters=RAT.ClassList([ProtectedRAT.models.Parameter(name='Substrate Roughness', min=1.0, value=3.0, max=5.0, fit=True, prior_type='uniform', mu=0.0, sigma=inf)]),
             background_parameters=RAT.ClassList([RAT.models.Parameter(name='Background Param 1', min=1e-07, value=1e-06, max=1e-05, fit=False, prior_type='uniform', mu=0.0, sigma=inf)]),
             scalefactors=RAT.ClassList([RAT.models.Parameter(name='Scalefactor 1', min=0.02, value=0.23, max=0.25, fit=False, prior_type='uniform', mu=0.0, sigma=inf)]),


### PR DESCRIPTION
This PR updates the backgrounds and resolutions in the tutorial to use `source` instead of `value_1` so that they work when we bump the RATapi version.

Also moves RATapi to `requirements.txt` as it is required to build the docs at all (due to the snippet generation), and pins its version