### PR TITLE
Improves MATLAB reference

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -28,6 +28,7 @@ jobs:
 
         wget https://github.com/RascalSoftware/RAT/releases/download/nightly/Linux.zip
         unzip Linux.zip -d API/
+        rm API/utilities/mockFunction.m  # as otherwise the MATLAB reference fails to parse it
 
         # we get pandoc from web as apt version is outdated
         wget https://github.com/jgm/pandoc/releases/download/3.6.2/pandoc-3.6.2-1-amd64.deb

--- a/source/reference/matlab/backgroundsClass.rst
+++ b/source/reference/matlab/backgroundsClass.rst
@@ -1,52 +1,19 @@
-.. _table: https://uk.mathworks.com/help/matlab/tables.html
-
 .. _backgroundsClass:
 
 =================
 Backgrounds Class
 =================
 
-This class makes the backgrounds in RAT. Backgrounds are defined in a two stage process. Firstly we define the actual fitted parameters. 
-These are held in a 'ParametersClass' table. Then, we group these into the backgrounds themselves using a multiTypeTable(`table`_). So, we can then use the 
-background parameters to either define background as constant, data or a function.
 
-.. list-table:: The methods on the left call the methods on the right in the table.
-    :widths: 50 50
-    :header-rows: 1
+The `backgroundsClass` holds data describing how background noise should be accounted for in the experiment. This data is the type of background (which can
+be either constant, a function, or from data), the source of the background, and any relevant parameters.
 
-    * - Method in Project Class
-      - Method in backgroundsClass 
-    * - projectClass.addBackgroundParam()
-      - backgroundsClass.backgroundParams.addParameter() 
-    * - projectClass.removeBackgroundParam()
-      - backgroundsClass.backgroundParams.removeParameter()
-    * - projectClass.setBackgroundParamValue()
-      - backgroundsClass.backgroundParams.setValue()
-    * - projectClass.addBackground()
-      - backgroundsClass.addBackground()
-    * - projectClass.removeBackground()
-      - backgroundsClass.removeBackground()
+- For a constant resolution, the source will be the name of a background parameter (added via `projectClass.addBackgroundParam`;
+- for a data resolution, it will be the name of a data object (added via `projectClass.addData`) with an optional offset background parameter in the `value_1` field;
+- for a function resolution, it will be the name of a custom file (added via `projectClass.addCustomFile`) with up to five background parameters used
+  in the function in fields `value_1` through to `value_5`.
 
-.. note::
- 1. For constant, only one parameter is supplied to multi type table. 
- 2. For data, only the data itself is supplied as a cell. 
- 3. For function, the function name is supplied, along with up to three parameters (from the parameters table) which are then supplied to the function to
-    calculate the background. 
-    
-In each case, the background can either be added to the simulation or subtracted from the data.
 
-.. code-block:: MATLAB
-    :caption: Example showing how backgroundsClass methods are called.
-
-        % Change the name of the existing parameters to refer to D2O
-        problem.setBacksPar(1,'name','Backs par D2O','fit',true,'min',1e-8,'max',1e-5);
-
-        % Add a new constant background
-        problem.addBackground('Background SMW','constant','Backs par SMW');
-
-*********
-Reference
-*********
 .. default-domain:: mat
 .. autoclass:: API.projectClass.backgroundsClass
     :members:

--- a/source/reference/matlab/contrastsClass.rst
+++ b/source/reference/matlab/contrastsClass.rst
@@ -1,48 +1,13 @@
 ===============
 Contrasts Class
 ===============
-Contrast Class is a class to responsible to manipulate contrasts. While adding the contrast, the input(cell array) goes through some checks and if no input is given, the contrast is 
+Contrast Class is a class to manipulate contrasts, which describe a single "experimental sample" (e.g. a level of deuteration).
+While adding the contrast, the input(cell array) goes through some checks and if no input is given, the contrast is 
 automatically named and counter is incremented. If only name was given, contrast is incremented and the cell array's name is set to current name.
 
 The cell array of contrasts is sent to Contrast Class to get converted to a struct `parseContrastInput` method which gets attached to the class object.
 
-.. code-block:: MATLAB
-    :caption: Adding a contrast (D20 Contrast)
 
-        problem.addContrast('name','Bilayer / D2O',...
-            'background','Background D2O',...
-            'resolution','Resolution 1',...
-            'scalefactor', 'Scalefactor 1',...
-            'resample',false,....
-            'bulkOut', 'SLD D2O',... 
-            'bulkIn', 'Silicon',...
-            'data', 'Bilayer / D2O');
-
-
-While setting contrasts to a model, `setContrastModel` method is called. This method is called with a cell array of a { number , cell array }. The number being what contrast 
-is and the cell array containing the information about the model. The main purpose of this method is to set the contrast to a model based on specified type of model. Based 
-on the type of model, the code checks whether some of the contrast names are allowed or not. If not, it throws an error.
-
-
-.. code-block:: MATLAB
-    :caption: Setting a contrast to a model
-
-        % 1 refers to the contrast number and the rest Layer information
-        problem.setContrastModel(1,{'Oxide Layer',...
-              'Water Layer',...
-              'Bil inner head',...
-              'Bil tail',...
-              'Bil tail',...
-              'Bil outer head'});
-
-***********************
-Domains Contrasts Class
-***********************
-The Domains Contrasts Class is a simplified model only contrasts class for the Domains calculation.
-
-*********
-Reference
-*********
 .. default-domain:: mat
 .. autoclass:: API.projectClass.contrastsClass
     :members:

--- a/source/reference/matlab/contrastsClass.rst
+++ b/source/reference/matlab/contrastsClass.rst
@@ -1,11 +1,7 @@
 ===============
 Contrasts Class
 ===============
-Contrast Class is a class to manipulate contrasts, which describe a single "experimental sample" (e.g. a level of deuteration).
-While adding the contrast, the input(cell array) goes through some checks and if no input is given, the contrast is 
-automatically named and counter is incremented. If only name was given, contrast is incremented and the cell array's name is set to current name.
-
-The cell array of contrasts is sent to Contrast Class to get converted to a struct `parseContrastInput` method which gets attached to the class object.
+The Contrasts Class is a class to manipulate contrasts, which describe a single "experimental sample" (e.g. a level of deuteration).
 
 
 .. default-domain:: mat

--- a/source/reference/matlab/customFileClass.rst
+++ b/source/reference/matlab/customFileClass.rst
@@ -15,8 +15,8 @@ The custom file table has the following columns:
 4. Path of the custom file
 
 If the 4 columns are supplied, a new row (cell array of strings) is made using the supplied inputs. Then, `addCustomFile` method is used to append the row to the object.
-This method takes care of the error checking and incrementing the count of the custom files. It also makes a table of the row supplied. This table helps with displaying it 
-properly on terminal.
+This method takes care of the error checking and incrementing the count of the custom files. The contents of the class are displayed as a table.
+
 
 .. note::
     RAT supports custom files in C++ (compiled to dynamic library), MATLAB, and Python.

--- a/source/reference/matlab/customFileClass.rst
+++ b/source/reference/matlab/customFileClass.rst
@@ -5,7 +5,7 @@ Custom File Class
 =================
 
 RAT enables users to define their own custom files. They can be linked to RAT through Custom File class. Like other classes, the inputs are checked for
-the right order and type. Also, it uses `table`_ data type to store the custom files. Custom files can be added or removed using the methods this class provides. 
+the right order and type.
 
 The custom file table has the following columns:
 
@@ -18,22 +18,8 @@ If the 4 columns are supplied, a new row (cell array of strings) is made using t
 This method takes care of the error checking and incrementing the count of the custom files. It also makes a table of the row supplied. This table helps with displaying it 
 properly on terminal.
 
-.. code-block:: MATLAB
-    :caption: Adding MATLAB custom file.
-
-        %                       Row Name   Custom File Name  Language   Path
-        problem.addCustomFile('DSPC Model','customBilayer.m','matlab',pwd);
-
-.. code-block:: MATLAB
-    :caption: Adding C++ custom file.
-
-            % For C++, function name of the cpp file is supplied
-            %                       Row Name        DLL/function Name  Language   Path
-            problem.addCustomFile('DSPC CPP Model','customBilayer','c++',pwd);
-
-
 .. note::
-    RAT only supports C++ (via dynamic library), MATLAB, and Python.
+    RAT supports custom files in C++ (compiled to dynamic library), MATLAB, and Python.
 
 
 *********

--- a/source/reference/matlab/dataClass.rst
+++ b/source/reference/matlab/dataClass.rst
@@ -17,34 +17,6 @@ The dataTable is a `table`_ with 4 columns. The following are the 4 columns:
    simulation, and the second element is the maximum value of the simulation. (optional)
 
 
-.. list-table:: The methods on the left call the methods on the right in the table.
-    :widths: 25 25
-    :header-rows: 1
-
-    * - Method in Project Class
-      - Method in Data Class 
-    * - projectClass.addData()
-      - dataClass.addData() 
-    * - projectClass.setData()
-      - dataClass.setData()
-
-
-Like other classes, it has methods to setData, setDataRange or any individual column/parameter. It also checks if the data given is in the right format, 
-and if so, it stores it. If not, it has proper conditional statements to pinpoint the error. Like warning about duplicate names, number of inputs, type of an
-input .. etc. 
-
-.. code-block:: MATLAB
-    :caption: Adding data. Usually, the data is in .dat files. So, `readmatrix` built-in method is used to read the data into a variable.
-
-        D2O_data = readmatrix('c_PLP0016596.dat');
-        % Add the data to the project
-        projectClass.addData('Bilayer / D2O', D2O_data(:,1:3));
-
-.. code-block:: MATLAB
-    :caption: Setting data range. (Min and Max values)
-
-        problem.setData(2,'dataRange',[0.013 0.35]);
-
 *********
 Reference
 *********

--- a/source/reference/matlab/entryFunctions.rst
+++ b/source/reference/matlab/entryFunctions.rst
@@ -1,7 +1,7 @@
 ===================
 RAT Entry Functions
 ===================
-Once a project and controls class have been created, RAT is run via the entrypoint:
+Once a project and controls class have been created, RAT is run via the `RAT` function:
 
 .. code-block:: MATLAB
     :caption: Sample usage of RAT class.
@@ -18,9 +18,7 @@ Once a project and controls class have been created, RAT is run via the entrypoi
 
 The RAT function turns the `projectClass` and `controlsClass` into relevant structs and cell arrays.
 
-Much of this is done to be compatible with MATLAB Coder. MATLAB Coder won't accept variable sized cell arrays 
-containing variable sized arrays, such as arrays of strings, in a field of a struct. The `parseClassToStructs`
-converts the user-friendly data input into an object that can be passed to compiled code.
+The `parseClassToStructs` function converts the user-friendly data input into an object that can be passed to compiled code.
 
 Then, the `RATMain` function redirects the control flow based on what procedure is selected in `controlsClass`.
 

--- a/source/reference/matlab/entryFunctions.rst
+++ b/source/reference/matlab/entryFunctions.rst
@@ -1,7 +1,7 @@
 ===================
 RAT Entry Functions
 ===================
-The user should begin by creating a project and controls object, then the user can run RAT like shown below
+Once a project and controls class have been created, RAT is run via the entrypoint:
 
 .. code-block:: MATLAB
     :caption: Sample usage of RAT class.
@@ -16,14 +16,14 @@ The user should begin by creating a project and controls object, then the user c
         [problem,results] = RAT(problem,controls);
 
 
-When the RAT function is called, the classes are passed into internal functions like `parseClassToStructs` which takes the classes and breaks them down into cells, 
-limits, priors and more importantly converts the project class to struct. 
+The RAT function turns the `projectClass` and `controlsClass` into relevant structs and cell arrays.
 
-Then, the `RATMain` function redirects the control flow based on what procedure is selected in controlsClass. One of the redirecting functions will call the reflectivityCalculation
-which starts the reflectivity calculation.
+Much of this is done to be compatible with MATLAB Coder. MATLAB Coder won't accept variable sized cell arrays 
+containing variable sized arrays, such as arrays of strings, in a field of a struct. The `parseClassToStructs`
+converts the user-friendly data input into an object that can be passed to compiled code.
 
-Some interesting data type changes are needed because of how things work with coder. Coder wont accept variable sized cell arrays contains variable sized arrays (strings for eg) 
-in a field of a struct. So, look at `parseClassToStructs` function to understand how the data is converted.
+Then, the `RATMain` function redirects the control flow based on what procedure is selected in `controlsClass`.
+
 
 .. default-domain:: mat
 .. autofunction:: API.RAT

--- a/source/reference/matlab/index.rst
+++ b/source/reference/matlab/index.rst
@@ -10,5 +10,6 @@ MATLAB API Reference
     controlClass
     entryFunctions
     targetFunctions
+    minimisers/index
     plotting
     utilities

--- a/source/reference/matlab/layersClass.rst
+++ b/source/reference/matlab/layersClass.rst
@@ -1,46 +1,11 @@
 ============
 Layers Class
 ============
+Layers give physical information for each layer in a slab model (such as thickness, SLD, roughness and hydration).
 Layers can be added as a group or individually. When added as a group, `addLayerGroup` method in projectClass iterates over the list of layers and
 adds them one by one using `addLayer` method which is used to add individual layers.
 
-.. list-table:: The methods on the left call the methods on the right in the table.
-    :widths: 25 25
-    :header-rows: 1
 
-    * - Method in Project Class
-      - Method in Layers Class 
-    * - projectClass.addLayerGroup()
-      - layersClass.addLayer() 
-    * - projectClass.addLayer()
-      - layersClass.addLayer()
-    * - projectClass.setLayerValue()
-      - layersClass.setLayerValue()
-
-
-.. code-block:: MATLAB
-    :caption: Adding layers as a group. Can set to a class using projectClass.addLayerGroup(Layers)
-
-        projectClass.addLayerGroup({waterLayer ; bilInnerHead ; bilTails ; bilOuterHead})
-
-
-.. code-block:: MATLAB
-    :caption: Adding layers individually. Can set to a class using projectClass.addLayer(Layer)
-
-        waterLayer = {
-            'Water Layer',...           % Layer name
-            'Water thick',...
-            'Water SLD',...
-            'Bilayer heads rough',...    % Outer interface of the water layer is a bilayer headgroup
-            'Water hydr',...
-            'Bulk out'
-        };
-
-        projectClass.addLayer(waterLayer);
-
-*********
-Reference
-*********
 .. default-domain:: mat
 .. autoclass:: API.projectClass.layersClass
     :members:

--- a/source/reference/matlab/minimisers/de.rst
+++ b/source/reference/matlab/minimisers/de.rst
@@ -1,0 +1,8 @@
+Differential Evolution
+----------------------
+
+See :ref:`DE` for information on differential evolution.
+
+.. default-domain:: mat
+.. automodule:: minimisers.DE
+   :members:

--- a/source/reference/matlab/minimisers/dream.rst
+++ b/source/reference/matlab/minimisers/dream.rst
@@ -1,0 +1,15 @@
+DREAM
+-----
+
+See :ref:`DREAM` for information on DREAM.
+
+.. default-domain:: mat
+.. automodule:: minimisers.DREAM
+   :members:
+
+.. automodule:: minimisers.DREAM.functions
+   :members:
+
+.. automodule:: minimisers.DREAM.postprocessing
+   :members:
+

--- a/source/reference/matlab/minimisers/generalUtils.rst
+++ b/source/reference/matlab/minimisers/generalUtils.rst
@@ -6,3 +6,6 @@ General utilities used by the minimisers.
 .. default-domain:: mat
 .. automodule:: minimisers.generalUtils
    :members:
+
+.. automodule:: minimisers.generalUtils.bayesStats
+   :members:

--- a/source/reference/matlab/minimisers/generalUtils.rst
+++ b/source/reference/matlab/minimisers/generalUtils.rst
@@ -1,0 +1,8 @@
+General Minimiser Utilities
+---------------------------
+
+General utilities used by the minimisers.
+
+.. default-domain:: mat
+.. automodule:: minimisers.generalUtils
+   :members:

--- a/source/reference/matlab/minimisers/index.rst
+++ b/source/reference/matlab/minimisers/index.rst
@@ -1,0 +1,17 @@
+Minimisers
+----------
+
+This submodule contains the minimisation algorithms used to optimise
+a model.
+
+For explanatory information on the minimisation algorithms,
+see the :ref:`algorithms section of the documentation<algorithms>`.
+
+.. toctree::
+   :maxdepth: 1
+
+   simplex
+   de
+   ns
+   dream
+   generalUtils

--- a/source/reference/matlab/minimisers/ns.rst
+++ b/source/reference/matlab/minimisers/ns.rst
@@ -1,0 +1,8 @@
+Nested Sampling
+---------------
+
+See :ref:`nestedSampling` for more information on nested sampling.
+
+.. default-domain:: mat
+.. automodule:: minimisers.NS
+   :members:

--- a/source/reference/matlab/minimisers/simplex.rst
+++ b/source/reference/matlab/minimisers/simplex.rst
@@ -1,0 +1,8 @@
+Simplex
+-------
+
+See :ref:`simplex` for more information on the Nelder-Mead Simplex method.
+
+.. default-domain:: mat
+.. automodule:: minimisers.simplex
+   :members:

--- a/source/reference/matlab/parametersClass.rst
+++ b/source/reference/matlab/parametersClass.rst
@@ -1,70 +1,14 @@
-.. _table: https://uk.mathworks.com/help/matlab/tables.html
-
 ================
 Parameters Class
 ================
 
 Parameters Class helps to add, set or remove parameters to the Project Class. The class has a constructor that gets initiated when Parameter class is called. This constructor 
-sets important initial values to the class obj (object) like variable name, types. It also initiates a "table" that helps to store all the parameters. Table is a really useful 
-data type provided by matlab. Check this link to know more about `table`_.
+sets important initial values to the class obj (object) like variable name, types, which are stored in a table. 
 
-.. list-table:: The methods on the left call the methods on the right in the table.
-    :widths: 25 25
-    :header-rows: 1
-
-    * - Method in Project Class
-      - Method in Parameters Class 
-    * - projectClass.addParameterGroup()
-      - parametersClass.addParameter() 
-    * - projectClass.addParameter()
-      - parametersClass.addParameter()
-    * - projectClass.removeParameter()
-      - parametersClass.removeParameter()
-    * - projectClass.setParameter()
-      - parametersClass.setParameter()
-    * - projectClass.setParameter()
-      - parametersClass.setValue()
-    
-      
 When adding parameters, they can be added individually or as a group (see below). When added as a group, `addParameterGroup` method in projectClass iterates over the 
 list of parameters and adds them one by one using `addParameter` method which is used to add individual parameters.
 
-.. code-block:: MATLAB 
-    :caption: Adding parameters as a group. Can set to a class using projectClass.addParameterGroup(Parameters)
 
-        Parameters = {
-        %   Name                min         val         max     fit? 
-        {'Oxide thick',         5,         20,         60,     true   };
-        {'Oxide SLD',           3e-6,       3.41e-6,    4e-6,   false  };
-        {'Oxide Hydration'      0,          20,         30,     true   }};
-
-
-.. code-block:: MATLAB 
-    :caption: Adding parameters individually. Can set to a class using projectClass.addParameter(Parameter)
-
-        Oxide =     {'Oxide Layer',...          % Name of the layer
-                    'Oxide thick',...           % Layer thickness
-                    'Oxide SLD',...             % Layer SLD
-                    'Substrate Roughness',...   % Layer roughness
-                    'Oxide Hydration',...       % Oxide hydration (percent)
-                    'bulk out' };               % Which bulk phase is hydrating the layer
-            
-    % Add this to the projectClass...
-    projectClass.addLayer(Oxide);
-
-When *addParameter* method is called, the method checks the input through a series of checks to find out
-if there are any unexpected values at unexpected places. For example, having logical value in place of a numerical value argument. With *setParameter* method, 
-one can set the value of any parameter independently. However, there are other methods that helps setting individual parameters. For example, *setName* method helps
-to set the name of a parameter.
-
-.. note::
-    
-    1. You can add Bulk in and Bulk out with this class 
-    2. You can add scale factor with this class
-
-*********
-Reference
-*********
 .. default-domain:: mat
 .. autoclass:: API.projectClass.parametersClass
     :members:

--- a/source/reference/matlab/parametersClass.rst
+++ b/source/reference/matlab/parametersClass.rst
@@ -3,7 +3,7 @@ Parameters Class
 ================
 
 Parameters Class helps to add, set or remove parameters to the Project Class. The class has a constructor that gets initiated when Parameter class is called. This constructor 
-sets important initial values to the class obj (object) like variable name, types, which are stored in a table. 
+sets important initial values to the class like variable names or types, which are stored in a table. 
 
 When adding parameters, they can be added individually or as a group (see below). When added as a group, `addParameterGroup` method in projectClass iterates over the 
 list of parameters and adds them one by one using `addParameter` method which is used to add individual parameters.

--- a/source/reference/matlab/projectClass.rst
+++ b/source/reference/matlab/projectClass.rst
@@ -1,12 +1,13 @@
 =============
 Project Class
 =============
-Project Class is all about data. It contains the very data user wants to work with. It stores all the data required for reflectivity calculations. 
-Everything in RAT comes from projectClass in one way or another. There are many functions that deal with breaking down the data from Project Class into smaller pieces 
-so that they can be used in other parts of the software.
+The project class objects contain the experimental data and model information which is used in the reflectivity calculation and optimisation algorithms. The two classes
+are `projectClass`, which is used for normal calculations, and `domainsClass`, which is used for domains calculations. The `domainsClass` contains additional information
+relating to the structure of the domains (`domainRatio` and `domainContrasts`).
 
+How to create and modify a project is explained in :ref:`the user guide<project>`.
 
-Project Class has lot of other classes that help create objects for inputs. They are : 
+The class itself mostly brings together the data structures describing the experimental model and data. These structures are:
 
 .. toctree::
     :maxdepth: 1
@@ -20,48 +21,13 @@ Project Class has lot of other classes that help create objects for inputs. They
     contrastsClass
 
 
-.. note::
-    Most of these classes have the following in common:
+The class is designed so that these data structures do not need to be accessed directly. For example, the bulk in parameters are stored in a `parametersClass`,
+and the method `projectClass.addBulkIn` will pass its arguments to the `parametersClass.addParameter` method of the bulk in `parametersClass`. The same
+applies to removing and changing data in each part of the project.
 
-    1. They are all called from Project Class.
-    2. Methods to add or remove or change an attribute depending on the class.
-    3. Methods to find the location based on input value. Finding row when given an attribute's name or vice versa (Not all of them though).
-    4. Display methods.
-    5. A 'toStruct' method which output the class parameters as a struct.
+It is recommended that a project is created using the `createProject` function instead of creating a `projectClass` or `domainsClass` object directly; this function will validate
+input arguments and allow the creation of both types of project from the same entrypoint.
 
-
-.. list-table:: The methods on the left call the methods on the right in the table.
-    :widths: 50 50
-    :header-rows: 1
-
-    * - Method in Project Class
-      - Method in Parameter Class 
-    * - projectClass.addBulkIn/addBulkOut()
-      - parametersClass.addParameter() 
-    * - projectClass.removeBulkIn/removeBulkOut()
-      - parametersClass.removeParameter()
-    * - projectClass.setBulkIn/setBulkOut()
-      - parametersClass.setParameter()
-
-Although, Project class provides one level higher interface so that one can use `addBulkIn` and `addBulkOut` methods from projectClass to set these parameters.
-
-.. code-block:: MATLAB
-    :caption: Adding Bulk Out. Can set to a class using projectClass.addBulkOut(BulkIn)
-
-        %                   Name       min     val   max  fit?
-        problem.addBulkOut({'SLD SMW',2e-6,2.073e-6,3e-6,true});
-
-*************
-Domains Class
-*************
-RAT currently supports two calculation types (normal and Domains). The Domains Class is a project class with extra parameters (domainRatio, domainContrasts) for the Domains calculation.
-
-.. note::
-    It is recommended to use `API.createProject` instead of creating a Project or Domains object directly.
-
-*********
-Reference
-*********
 .. default-domain:: mat
 .. autofunction:: API.createProject
 

--- a/source/reference/matlab/resolutionsClass.rst
+++ b/source/reference/matlab/resolutionsClass.rst
@@ -4,24 +4,11 @@
 Resolutions Class
 =================
 
-Resolutions are defined in a two stage process. Firstly, actual fitted parameters are defined. These are held in a 'Parameter Class' table (referring to data type).
-Then, these are grouped into the resolutions themselves using a multi-type table. Then the resolution parameters can be used to either define resolution as 
-constant, data, or a function. 
+The `resolutionsClass` holds data describing how instrument resolution should be accounted for in the experiment. This data is the type of resolution (which can
+be either constant or from data) and the source of the resolution; for a constant resolution, this is the name of a resolution parameter (added via `projectClass.addResolutionParam`);
+for data, this will be taken from the fourth column of the data array used by the contrast.
 
-The constructor is called with the parameters and resolutions as input. The parameters are stored in the resolPars table whereas the resolutions are stored in 
-the resolutions table and the allowed types are defined in the allowedTypes variable.
 
-.. note::
-
-    1. For constant only one parameter is supplied to multi-type table. 
-    2. For data, the name is supplied, along with name of the data in the data table. 
-    3. For function, the function name is supplied, along with up to three parameters (from the parameters table) which are then supplied to the function to calculate the resolution. 
-
-In each case, the Resolutions can either be added to or subtracted from the data.
-
-*********
-Reference
-*********
 .. default-domain:: mat
 .. autoclass:: API.projectClass.resolutionsClass
     :members:

--- a/source/reference/matlab/targetFunctions.rst
+++ b/source/reference/matlab/targetFunctions.rst
@@ -2,38 +2,33 @@
 Target Functions (Low Level API)
 ================================
 
-..
-  .. default-domain:: mat
-  .. automodule:: targetFunctions
-      :members:
 
-  .. _CommonFunctions:
+.. default-domain:: mat
+.. automodule:: targetFunctions
+    :members:
 
-  Common Functions
-  ----------------
-  .. automodule:: targetFunctions.common
-      :members:
+.. _CommonFunctions:
 
-  .. automodule:: targetFunctions.common.costFunctions
-      :members: 
+Common Functions
+----------------
+.. automodule:: targetFunctions.common
+    :members:
 
-  .. automodule:: targetFunctions.common.groupLayers
-      :members:    
+.. automodule:: targetFunctions.common.costFunctions
+    :members: 
 
-  .. _normalTF:
+.. automodule:: targetFunctions.common.groupLayers
+    :members:    
 
-  Normal Target Functions (normalTF)
 
-  .. automodule:: targetFunctions.+normalTF.+customLayers
-      :members:
+Normal Target Functions (normalTF)
+----------------------------------
 
-  .. automodule:: targetFunctions.+normalTF.+customXY
-      :members:
+.. automodule:: targetFunctions.+normalTF
+    :members:
 
-  Domains Target Functions (domainsTF)
-  ------------------------------------
-  .. automodule:: targetFunctions.+domainsTF.+customLayers
-      :members:
+Domains Target Functions (domainsTF)
+------------------------------------
 
-  .. automodule:: targetFunctions.+domainsTF.+customXY
-      :members:
+.. automodule:: targetFunctions.+domainsTF
+   :members:

--- a/source/reference/matlab/utilities.rst
+++ b/source/reference/matlab/utilities.rst
@@ -48,9 +48,6 @@ Developer utilities
 .. autoclass:: utilities.dyLibWrapper
    :members:
 
-.. autoclass:: utilities.mockFunction
-   :members:
-
 .. autofunction:: utilities.misc.randSample
 
 .. autofunction:: utilities.misc.kde

--- a/source/reference/matlab/utilities.rst
+++ b/source/reference/matlab/utilities.rst
@@ -18,22 +18,41 @@ Developer utilities
 
 .. default-domain:: mat
 .. autofunction:: utilities.copyProperties
-.. autofunction:: utilities.customEnum
-.. autofunction:: utilities.dyLibWrapper
+
 .. autofunction:: utilities.isFigure
+
 .. autofunction:: utilities.isText
-.. autofunction:: utilities.mockFunction
+
 .. autofunction:: utilities.mustBeScalarOrEmptyLogical
-.. autofunction:: utilities.pythonWrapper
+
 .. autofunction:: utilities.textProgressBar
+
 .. autofunction:: utilities.validateLimits
+
 .. autofunction:: utilities.validateLogical
+
 .. autofunction:: utilities.validateNumber
+
 .. autofunction:: utilities.validateOption
+
 .. autofunction:: utilities.validateParameter
+
 .. autofunction:: utilities.validatePriors
 
+.. autoclass:: utilities.pythonWrapper
+   :members:
+
+.. autoclass:: utilities.customEnum
+   :members:
+
+.. autoclass:: utilities.dyLibWrapper
+   :members:
+
+.. autoclass:: utilities.mockFunction
+   :members:
+
 .. autofunction:: utilities.misc.randSample
+
 .. autofunction:: utilities.misc.kde
 
 .. automodule:: utilities.+exceptions 

--- a/source/reference/matlab/utilities.rst
+++ b/source/reference/matlab/utilities.rst
@@ -1,8 +1,39 @@
 =========
 Utilities
 =========
+RAT contains a variety of utility functions, mostly for development but some are for file reading and conversion.
+
+File reading and conversion
+---------------------------
 
 .. default-domain:: mat
+.. autofunction:: utilities.readOrso
+
 .. autofunction:: utilities.misc.projectClassToR1
 
 .. autofunction:: utilities.misc.r1ToProjectClass
+
+Developer utilities
+-------------------
+
+.. default-domain:: mat
+.. autofunction:: utilities.copyProperties
+.. autofunction:: utilities.customEnum
+.. autofunction:: utilities.dyLibWrapper
+.. autofunction:: utilities.isFigure
+.. autofunction:: utilities.isText
+.. autofunction:: utilities.mockFunction
+.. autofunction:: utilities.mustBeScalarOrEmptyLogical
+.. autofunction:: utilities.pythonWrapper
+.. autofunction:: utilities.textProgressBar
+.. autofunction:: utilities.validateLimits
+.. autofunction:: utilities.validateLogical
+.. autofunction:: utilities.validateNumber
+.. autofunction:: utilities.validateOption
+.. autofunction:: utilities.validateParameter
+.. autofunction:: utilities.validatePriors
+
+.. autofunction:: utilities.misc.randSample
+.. autofunction:: utilities.misc.kde
+
+.. automodule:: utilities.+exceptions 


### PR DESCRIPTION
This PR fixes #33 by:

- makes current MATLAB reference more concise/encyclopedic and links to the tutorial for usage information instead
- adds remainder of utilities to reference
- adds minimisers to reference