### PR TITLE
Improves behaviour with no matlab engine

### DIFF
--- a/source/_ext/snippets.py
+++ b/source/_ext/snippets.py
@@ -1,6 +1,5 @@
 """Sphinx directive for building code from snippets."""
 
-import warnings
 from contextlib import redirect_stdout
 from io import StringIO
 
@@ -45,8 +44,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
 
     def setup_envs(*ignore):
         """Initialise Python/MATLAB environments."""
-        app.env.snippets_env = {"RAT": RATapi}
-        print("Starting up MATLAB Engine...")
+        app.env.snippets_env = {"RAT": RATapi} 
         app.env.matlab_engine = setup_matlab()
         app.env.matlab_engine.eval(
             "cd('API'); addPaths; cd('..'); ratVars = who;", nargout=0
@@ -74,8 +72,7 @@ class FallbackMatlabEngine:
     """A fallback class that intercepts calls to MATLAB engine when the engine is not available."""
 
     def eval(self, *args, **kwargs):
-        print("Could not create output as MATLAB engine not available!")
-        warnings.warn("Could not create output as MATLAB engine was not available.")
+        pass 
 
     def quit(self):
         pass
@@ -88,6 +85,7 @@ def setup_matlab():
     except ImportError:
         return FallbackMatlabEngine()
 
+    print("Starting up MATLAB Engine for snippets...")
     return start_matlab()
 
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,6 +14,8 @@ from importlib import metadata
 from urllib.parse import urljoin
 from urllib.request import urlretrieve
 from pathlib import Path
+
+
 # -- Project information -----------------------------------------------------
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -52,6 +54,13 @@ templates_path = ['_templates']
 # -- Setup example files -----------------------------------------------------
 PYTHON_RAT_RELEASE = metadata.version("RATapi")
 
+MATLAB_AVAILABLE = True
+try:
+    from matlab.engine import start_matlab
+except ImportError:
+    print("MATLAB Engine not found. Some examples and code blocks may be missing.")
+    MATLAB_AVAILABLE = False
+
 if not os.path.isdir("./python_examples/data"):
     zip_dir, headers = urlretrieve(f"https://github.com/RascalSoftware/python-RAT/archive/refs/tags/{PYTHON_RAT_RELEASE}.zip")
     with zipfile.ZipFile(zip_dir) as zf:
@@ -60,18 +69,18 @@ if not os.path.isdir("./python_examples/data"):
     for directory in ['normal_reflectivity', 'domains', 'absorption', 'convert_rascal_project']:
         for file in Path(f"./python-RAT-{PYTHON_RAT_RELEASE}/RATapi/examples/{directory}/").glob('*'):
             shutil.copy(file, "./python_examples/notebooks/")
+    if MATLAB_AVAILABLE:  # convert_rascal example requires matlab engine
+        for file in Path(f"./python-RAT-{PYTHON_RAT_RELEASE}/RATapi/examples/convert_rascal_project/").glob('*'):
+            shutil.copy(file, "./python_examples/notebooks/")
+
 
     shutil.copytree(f"./python-RAT-{PYTHON_RAT_RELEASE}/RATapi/examples/data", "./python_examples/data", dirs_exist_ok=True)
 
     shutil.rmtree(f"./python-RAT-{PYTHON_RAT_RELEASE}")
 
 if not os.path.isfile("./matlab_examples/standardLayersDSPCSheet.html"):
-    try:
-        from matlab.engine import start_matlab
-    except ImportError:
-        print("Could not copy MATLAB live scripts as MATLAB is not installed.")
-    else:
-        print("Starting MATLAB Engine...")
+    if MATLAB_AVAILABLE: 
+        print("Starting MATLAB Engine for live scripts...")
         eng = start_matlab()
         matlab_examples_path = Path("./matlab_examples").resolve()
         eng.eval("cd('../API'); addPaths;", nargout=0)

--- a/source/conf.py
+++ b/source/conf.py
@@ -66,7 +66,7 @@ if not os.path.isdir("./python_examples/data"):
     with zipfile.ZipFile(zip_dir) as zf:
         zf.extractall()
     print("Copying Jupyter notebooks...")
-    for directory in ['normal_reflectivity', 'domains', 'absorption', 'convert_rascal_project']:
+    for directory in ['normal_reflectivity', 'domains', 'absorption']:
         for file in Path(f"./python-RAT-{PYTHON_RAT_RELEASE}/RATapi/examples/{directory}/").glob('*'):
             shutil.copy(file, "./python_examples/notebooks/")
     if MATLAB_AVAILABLE:  # convert_rascal example requires matlab engine


### PR DESCRIPTION
This PR makes it possible for the docs to build with no MATLAB engine (by moving the loading of convert_rascal) and also makes the logs output less when MATLAB engine is not present.
